### PR TITLE
feat(oxyii): protocol primitives + native unit tests for T8520

### DIFF
--- a/include/OxyIIProtocol.h
+++ b/include/OxyIIProtocol.h
@@ -1,0 +1,276 @@
+#ifndef OXYII_PROTOCOL_H
+#define OXYII_PROTOCOL_H
+
+// OxyII application-layer protocol for Wellue T8520 / O2Ring-S.
+//
+// Pure-C++ inline functions; no Arduino, FreeRTOS, or ESP-IDF deps. Builds in
+// the native test env and on the ESP32. Mirrors scripts/o2r_pair/oxyii_protocol.py
+// in the admin/sleep repo, validated against captured ViHealth-app snoop frames.
+//
+// AES-128/ECB/PKCS7 wrap/unwrap is intentionally NOT in this header — encryption
+// is per-command and integrates with mbedtls on-device, so it lives in a separate
+// translation unit gated by the platform. The frame codec (CRC + envelope) is
+// fully testable on the host, which is what's covered here.
+//
+// Frame format (request and response share opcode):
+//
+//     +------+-----+------+------+-----+--------+--------+----------+-----+
+//     | 0xA5 | cmd | ~cmd | flag | seq | len_lo | len_hi | payload  | crc |
+//     +------+-----+------+------+-----+--------+--------+----------+-----+
+//        1     1     1      1     1     1        1        len bytes   1
+//
+//   - flag is 0x00 in normal app->device commands.
+//   - len is little-endian payload byte count.
+//   - crc is CRC-8/poly 0x07/init 0/no reflection/no xorout, computed over
+//     the entire frame except the trailing crc byte itself.
+
+#include <cstdint>
+#include <cstring>
+
+namespace OxyIIProtocol {
+
+// BLE GATT UUIDs (NOT the legacy 14839ac4 OxyII; T8520 uses these)
+inline const char* SERVICE_UUID() { return "e8fb0001-a14b-98f9-831b-4e2941d01248"; }
+inline const char* WRITE_UUID()   { return "e8fb0002-a14b-98f9-831b-4e2941d01248"; }
+inline const char* NOTIFY_UUID()  { return "e8fb0003-a14b-98f9-831b-4e2941d01248"; }
+
+// Opcodes — extracted from doab/dof.java dispatch table in the lepu-blepro AAR
+constexpr uint8_t OP_AUTH               = 0xFF;
+constexpr uint8_t OP_KEEPALIVE          = 0x10;
+constexpr uint8_t OP_SET_UTC_TIME       = 0xC0;
+constexpr uint8_t OP_HANDSHAKE          = 0x00;
+constexpr uint8_t OP_GET_INFO           = 0xE1;
+constexpr uint8_t OP_GET_BATTERY        = 0xE4;
+constexpr uint8_t OP_GET_FILE_LIST      = 0xF1;
+constexpr uint8_t OP_READ_FILE_START    = 0xF2;
+constexpr uint8_t OP_READ_FILE_DATA     = 0xF3;
+constexpr uint8_t OP_READ_FILE_END      = 0xF4;
+
+constexpr uint8_t FRAME_LEAD = 0xA5;
+constexpr size_t  FRAME_HEADER_LEN = 7;
+constexpr size_t  AES_BLOCK_SIZE = 16;
+constexpr size_t  AES_KEY_SIZE   = 16;
+
+// CRC-8/poly=0x07, init=0, no reflection. Caller passes the frame minus the
+// trailing CRC byte (i.e. compute, append, send).
+inline uint8_t crc8(const uint8_t* data, size_t len) {
+    uint8_t crc = 0;
+    for (size_t i = 0; i < len; i++) {
+        crc ^= data[i];
+        for (int b = 0; b < 8; b++) {
+            crc = (crc & 0x80) ? static_cast<uint8_t>((crc << 1) ^ 0x07)
+                               : static_cast<uint8_t>(crc << 1);
+        }
+    }
+    return crc;
+}
+
+// Build a complete request frame into out[]. Returns total byte count, or 0 on
+// invalid input (out too small for header + payload + crc). out must be at
+// least FRAME_HEADER_LEN + payloadLen + 1 bytes.
+inline size_t encodeFrame(uint8_t opcode, const uint8_t* payload, size_t payloadLen,
+                          uint8_t seq, uint8_t* out, size_t outCap) {
+    if (payloadLen > 0xFFFF) return 0;
+    size_t total = FRAME_HEADER_LEN + payloadLen + 1;
+    if (outCap < total) return 0;
+
+    out[0] = FRAME_LEAD;
+    out[1] = opcode;
+    out[2] = static_cast<uint8_t>(~opcode);
+    out[3] = 0x00; // flag
+    out[4] = seq;
+    out[5] = static_cast<uint8_t>(payloadLen & 0xFF);
+    out[6] = static_cast<uint8_t>((payloadLen >> 8) & 0xFF);
+    if (payload && payloadLen > 0) {
+        memcpy(out + FRAME_HEADER_LEN, payload, payloadLen);
+    }
+    out[FRAME_HEADER_LEN + payloadLen] = crc8(out, FRAME_HEADER_LEN + payloadLen);
+    return total;
+}
+
+// Decode result from validating an incoming notify frame.
+struct DecodedFrame {
+    bool     ok;
+    uint8_t  opcode;
+    uint8_t  seq;
+    size_t   payloadOffset;   // index into the input frame where payload begins
+    size_t   payloadLen;
+    uint8_t  errorCode;       // populated when ok == false; see DecodeError below
+};
+
+enum DecodeError : uint8_t {
+    DECODE_OK             = 0,
+    DECODE_TOO_SHORT      = 1,
+    DECODE_BAD_LEAD       = 2,
+    DECODE_BAD_COMPLEMENT = 3,
+    DECODE_BAD_LENGTH     = 4,
+    DECODE_BAD_CRC        = 5,
+};
+
+inline DecodedFrame decodeFrame(const uint8_t* frame, size_t frameLen) {
+    DecodedFrame d{};
+    if (frameLen < FRAME_HEADER_LEN + 1) {
+        d.errorCode = DECODE_TOO_SHORT;
+        return d;
+    }
+    if (frame[0] != FRAME_LEAD) {
+        d.errorCode = DECODE_BAD_LEAD;
+        return d;
+    }
+    uint8_t op = frame[1];
+    if (frame[2] != static_cast<uint8_t>(~op)) {
+        d.errorCode = DECODE_BAD_COMPLEMENT;
+        return d;
+    }
+    uint16_t length = static_cast<uint16_t>(frame[5]) |
+                      (static_cast<uint16_t>(frame[6]) << 8);
+    size_t expectedTotal = FRAME_HEADER_LEN + length + 1;
+    if (frameLen != expectedTotal) {
+        d.errorCode = DECODE_BAD_LENGTH;
+        return d;
+    }
+    uint8_t expectedCrc = crc8(frame, expectedTotal - 1);
+    if (frame[expectedTotal - 1] != expectedCrc) {
+        d.errorCode = DECODE_BAD_CRC;
+        return d;
+    }
+    d.ok = true;
+    d.opcode = op;
+    d.seq = frame[4];
+    d.payloadOffset = FRAME_HEADER_LEN;
+    d.payloadLen = length;
+    return d;
+}
+
+// Even-indexed bytes of MD5("lepucloud") — Wellue's well-known salt. These are
+// the constant inputs to the session-key derivation; the AAR computes the MD5
+// once at module load. Pre-computed here to avoid pulling mbedtls into the
+// pure-protocol layer.
+inline const uint8_t* lepucloudSaltEvenBytes() {
+    // MD5("lepucloud") = c2 a7 cf 50 da fe d8 85 a8 f8 f7 ea c4 43 35 f3
+    // Even indices [0,2,4,6,8,10,12,14] = c2 cf da d8 a8 f7 c4 35
+    static const uint8_t kSalt[8] = {
+        0xc2, 0xcf, 0xda, 0xd8, 0xa8, 0xf7, 0xc4, 0x35
+    };
+    return kSalt;
+}
+
+// Compute the 16-byte AES session key per Wellue's doaj.doaf.doa(String).
+//
+// Layout:
+//   [0..7]   = even-indexed bytes of MD5("lepucloud")
+//   [8..11]  = first 4 ASCII chars of `serial`
+//   [12..15] = timestamp shifted by 0,1,2,3 — NOT byte-extract — per the AAR's
+//              literal `(byte)(l2 >> n3)` for n3 = 0..3.
+//
+// Returns false when serial is shorter than 4 chars.
+inline bool deriveSessionKey(const char* serial, size_t serialLen,
+                             uint64_t timestampSeconds, uint8_t outKey[AES_KEY_SIZE]) {
+    if (serialLen < 4) return false;
+    const uint8_t* salt = lepucloudSaltEvenBytes();
+    for (int i = 0; i < 8; i++) outKey[i] = salt[i];
+    for (int i = 0; i < 4; i++) outKey[8 + i] = static_cast<uint8_t>(serial[i]);
+    for (int n = 0; n < 4; n++) {
+        outKey[12 + n] = static_cast<uint8_t>((timestampSeconds >> n) & 0xFF);
+    }
+    return true;
+}
+
+// Build the READ_FILE_START (0xF2) payload: a 20-byte buffer with a 16-byte
+// null-padded ASCII filename slot followed by a u32 LE file_type field.
+// Returns false when outCap < 20 or filenameLen > 16.
+inline bool buildReadFileStartPayload(const char* filename, size_t filenameLen,
+                                       uint8_t fileType, uint8_t* out, size_t outCap) {
+    if (outCap < 20 || filenameLen > 16) return false;
+    memset(out, 0, 20);
+    memcpy(out, filename, filenameLen);
+    out[16] = fileType;
+    out[17] = 0;
+    out[18] = 0;
+    out[19] = 0;
+    return true;
+}
+
+// Build the READ_FILE_DATA (0xF3) payload: a single u32 LE offset.
+inline bool buildReadFileDataPayload(uint32_t offset, uint8_t* out, size_t outCap) {
+    if (outCap < 4) return false;
+    out[0] = static_cast<uint8_t>(offset & 0xFF);
+    out[1] = static_cast<uint8_t>((offset >> 8) & 0xFF);
+    out[2] = static_cast<uint8_t>((offset >> 16) & 0xFF);
+    out[3] = static_cast<uint8_t>((offset >> 24) & 0xFF);
+    return true;
+}
+
+// Parsed GET_INFO reply (60-byte payload from the OxyII E1 response).
+// Only sn and firmware are surfaced; the rest of the payload bytes are
+// reserved for a future caller that wants battery/storage/etc. info.
+struct DeviceInfo {
+    bool ok;
+    char    firmwareVersion[9];   // 8-char ASCII + null
+    char    serialNumber[33];     // generous cap; T8520 reports 10 chars
+};
+
+inline DeviceInfo parseGetInfoReply(const uint8_t* payload, size_t payloadLen) {
+    DeviceInfo info{};
+    if (payloadLen < 48) return info;
+    // firmware version at [9..17]
+    for (int i = 0; i < 8; i++) info.firmwareVersion[i] = static_cast<char>(payload[9 + i]);
+    info.firmwareVersion[8] = '\0';
+    // strip trailing nulls in fw string
+    for (int i = 7; i >= 0 && info.firmwareVersion[i] == '\0'; i--) info.firmwareVersion[i] = '\0';
+    // serial-number length at [37], chars start at [38]
+    uint8_t snLen = payload[37];
+    if (snLen == 0 || static_cast<size_t>(38 + snLen) > payloadLen ||
+        snLen >= sizeof(info.serialNumber)) {
+        info.serialNumber[0] = '\0';
+    } else {
+        for (size_t i = 0; i < snLen; i++) {
+            info.serialNumber[i] = static_cast<char>(payload[38 + i]);
+        }
+        info.serialNumber[snLen] = '\0';
+    }
+    info.ok = true;
+    return info;
+}
+
+// One file entry from a GET_FILE_LIST reply. Names are timestamp strings
+// like "20260427105949" (14 chars).
+constexpr size_t FILE_NAME_SLOT = 16;
+constexpr size_t MAX_FILE_NAME  = 14;
+
+struct FileListIter {
+    const uint8_t* plaintext;
+    size_t         plaintextLen;
+    uint8_t        count;       // declared count from byte [0]
+    size_t         pos;         // next-slot offset into plaintext
+};
+
+inline FileListIter beginFileList(const uint8_t* plaintext, size_t plaintextLen) {
+    FileListIter it{};
+    it.plaintext = plaintext;
+    it.plaintextLen = plaintextLen;
+    if (plaintextLen >= 1) {
+        it.count = plaintext[0];
+        it.pos = 1;
+    }
+    return it;
+}
+
+// Pull the next filename into outName (must be MAX_FILE_NAME + 1 = 17 bytes).
+// Returns true if a name was emitted, false at end-of-list or on truncation.
+inline bool nextFilename(FileListIter& it, char outName[MAX_FILE_NAME + 2]) {
+    if (it.pos + FILE_NAME_SLOT > it.plaintextLen) return false;
+    const uint8_t* slot = it.plaintext + it.pos;
+    size_t n = 0;
+    while (n < MAX_FILE_NAME && slot[n] != 0x00) {
+        outName[n] = static_cast<char>(slot[n]);
+        n++;
+    }
+    outName[n] = '\0';
+    it.pos += FILE_NAME_SLOT;
+    return n > 0;
+}
+
+}  // namespace OxyIIProtocol
+
+#endif  // OXYII_PROTOCOL_H

--- a/test/test_oxyii_protocol/test_oxyii_protocol.cpp
+++ b/test/test_oxyii_protocol/test_oxyii_protocol.cpp
@@ -1,0 +1,324 @@
+// Unity tests for OxyIIProtocol — port of admin/sleep's
+// scripts/o2r_pair/test_oxyii_protocol.py. Exercises CRC, frame encode/decode,
+// session-key derivation, and reply parsers against the same captured ViHealth
+// snoop frames used in the Python suite.
+
+#include <unity.h>
+#include <cstdint>
+#include <cstring>
+
+#include "OxyIIProtocol.h"
+
+using namespace OxyIIProtocol;
+
+void setUp(void) {}
+void tearDown(void) {}
+
+static int hexNibble(char c) {
+    if (c >= '0' && c <= '9') return c - '0';
+    if (c >= 'a' && c <= 'f') return c - 'a' + 10;
+    if (c >= 'A' && c <= 'F') return c - 'A' + 10;
+    return -1;
+}
+
+// Decode a hex string like "a5e11e00020000bf" into out[]. Returns byte count.
+static size_t fromHex(const char* hex, uint8_t* out, size_t outCap) {
+    size_t n = 0;
+    while (hex[0] && hex[1] && n < outCap) {
+        int hi = hexNibble(hex[0]);
+        int lo = hexNibble(hex[1]);
+        if (hi < 0 || lo < 0) break;
+        out[n++] = static_cast<uint8_t>((hi << 4) | lo);
+        hex += 2;
+    }
+    return n;
+}
+
+// ----- CRC: snoop-frame regression (matches Python SNOOP_FRAMES) -----
+
+void test_crc_get_info_seq2_matches_snoop() {
+    // a5 e1 1e 00 02 00 00 bf
+    uint8_t frame[16];
+    size_t n = fromHex("a5e11e00020000bf", frame, sizeof(frame));
+    TEST_ASSERT_EQUAL_size_t(8, n);
+    TEST_ASSERT_EQUAL_UINT8(0xBF, crc8(frame, n - 1));
+}
+
+void test_crc_set_utc_time_seq1_matches_snoop() {
+    uint8_t frame[32];
+    size_t n = fromHex("a5c03f00010800ea07041b0b0808ce8a", frame, sizeof(frame));
+    TEST_ASSERT_EQUAL_UINT8(0x8A, crc8(frame, n - 1));
+}
+
+void test_crc_keepalive_matches_snoop() {
+    uint8_t frame[16];
+    size_t n = fromHex("a510ef000001000007", frame, sizeof(frame));
+    TEST_ASSERT_EQUAL_UINT8(0x07, crc8(frame, n - 1));
+}
+
+void test_crc_handshake_matches_snoop() {
+    uint8_t frame[16];
+    size_t n = fromHex("a500ff00010000d3", frame, sizeof(frame));
+    TEST_ASSERT_EQUAL_UINT8(0xD3, crc8(frame, n - 1));
+}
+
+void test_crc_auth_with_encrypted_payload_matches_snoop() {
+    // cmd=0xFF, encrypted setup payload — captures show 16-byte payload + crc
+    uint8_t frame[64];
+    size_t n = fromHex(
+        "a5ff00000010000068158872091cb098c8c7da23b04ccfb7", frame, sizeof(frame));
+    TEST_ASSERT_EQUAL_UINT8(0xB7, crc8(frame, n - 1));
+}
+
+// ----- encodeFrame: must produce exact ViHealth bytes -----
+
+void test_encode_get_info_matches_snoop() {
+    uint8_t out[16];
+    size_t n = encodeFrame(OP_GET_INFO, nullptr, 0, /*seq=*/2, out, sizeof(out));
+    TEST_ASSERT_EQUAL_size_t(8, n);
+    TEST_ASSERT_EQUAL_UINT8(0xA5, out[0]);
+    TEST_ASSERT_EQUAL_UINT8(0xE1, out[1]);
+    TEST_ASSERT_EQUAL_UINT8(0x1E, out[2]);
+    TEST_ASSERT_EQUAL_UINT8(0x00, out[3]);
+    TEST_ASSERT_EQUAL_UINT8(0x02, out[4]);
+    TEST_ASSERT_EQUAL_UINT8(0x00, out[5]);
+    TEST_ASSERT_EQUAL_UINT8(0x00, out[6]);
+    TEST_ASSERT_EQUAL_UINT8(0xBF, out[7]);
+}
+
+void test_encode_set_utc_time_matches_snoop() {
+    uint8_t payload[8];
+    size_t pn = fromHex("ea07041b0b0808ce", payload, sizeof(payload));
+    TEST_ASSERT_EQUAL_size_t(8, pn);
+
+    uint8_t out[32];
+    size_t n = encodeFrame(0xC0, payload, pn, /*seq=*/1, out, sizeof(out));
+    TEST_ASSERT_EQUAL_size_t(16, n);
+
+    uint8_t expected[16];
+    fromHex("a5c03f00010800ea07041b0b0808ce8a", expected, sizeof(expected));
+    TEST_ASSERT_EQUAL_UINT8_ARRAY(expected, out, 16);
+}
+
+void test_encode_large_payload_uses_little_endian_length() {
+    // 768-byte payload — verifies len_lo/len_hi split
+    uint8_t payload[768];
+    for (size_t i = 0; i < sizeof(payload); i++) payload[i] = static_cast<uint8_t>(i & 0xFF);
+
+    uint8_t out[800];
+    size_t n = encodeFrame(0xF3, payload, sizeof(payload), /*seq=*/7, out, sizeof(out));
+    TEST_ASSERT_EQUAL_size_t(7 + 768 + 1, n);
+    TEST_ASSERT_EQUAL_UINT8(0x07, out[4]);  // seq
+    TEST_ASSERT_EQUAL_UINT8(0x00, out[5]);  // len_lo
+    TEST_ASSERT_EQUAL_UINT8(0x03, out[6]);  // len_hi
+}
+
+void test_encode_returns_zero_when_outcap_too_small() {
+    uint8_t out[4];
+    size_t n = encodeFrame(OP_GET_INFO, nullptr, 0, 0, out, sizeof(out));
+    TEST_ASSERT_EQUAL_size_t(0, n);
+}
+
+// ----- decodeFrame -----
+
+void test_decode_roundtrip_with_payload() {
+    uint8_t raw[10] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+    uint8_t encoded[32];
+    size_t n = encodeFrame(0xF3, raw, sizeof(raw), /*seq=*/42, encoded, sizeof(encoded));
+
+    DecodedFrame d = decodeFrame(encoded, n);
+    TEST_ASSERT_TRUE(d.ok);
+    TEST_ASSERT_EQUAL_UINT8(0xF3, d.opcode);
+    TEST_ASSERT_EQUAL_UINT8(42, d.seq);
+    TEST_ASSERT_EQUAL_size_t(7, d.payloadOffset);
+    TEST_ASSERT_EQUAL_size_t(10, d.payloadLen);
+    TEST_ASSERT_EQUAL_UINT8_ARRAY(raw, encoded + d.payloadOffset, d.payloadLen);
+}
+
+void test_decode_rejects_bad_lead() {
+    uint8_t encoded[16];
+    size_t n = encodeFrame(OP_GET_INFO, nullptr, 0, 0, encoded, sizeof(encoded));
+    encoded[0] = 0xAA;
+
+    DecodedFrame d = decodeFrame(encoded, n);
+    TEST_ASSERT_FALSE(d.ok);
+    TEST_ASSERT_EQUAL_UINT8(DECODE_BAD_LEAD, d.errorCode);
+}
+
+void test_decode_rejects_bad_complement() {
+    uint8_t encoded[16];
+    size_t n = encodeFrame(OP_GET_INFO, nullptr, 0, 0, encoded, sizeof(encoded));
+    encoded[2] = 0x00;
+
+    DecodedFrame d = decodeFrame(encoded, n);
+    TEST_ASSERT_FALSE(d.ok);
+    TEST_ASSERT_EQUAL_UINT8(DECODE_BAD_COMPLEMENT, d.errorCode);
+}
+
+void test_decode_rejects_bad_crc() {
+    uint8_t encoded[16];
+    size_t n = encodeFrame(OP_GET_INFO, nullptr, 0, 0, encoded, sizeof(encoded));
+    encoded[n - 1] ^= 0x55;
+
+    DecodedFrame d = decodeFrame(encoded, n);
+    TEST_ASSERT_FALSE(d.ok);
+    TEST_ASSERT_EQUAL_UINT8(DECODE_BAD_CRC, d.errorCode);
+}
+
+void test_decode_rejects_short_frame() {
+    uint8_t tiny[3] = {0xA5, 0xE1, 0x1E};
+    DecodedFrame d = decodeFrame(tiny, sizeof(tiny));
+    TEST_ASSERT_FALSE(d.ok);
+    TEST_ASSERT_EQUAL_UINT8(DECODE_TOO_SHORT, d.errorCode);
+}
+
+void test_decode_rejects_length_mismatch() {
+    uint8_t encoded[16];
+    size_t n = encodeFrame(OP_GET_INFO, nullptr, 0, 0, encoded, sizeof(encoded));
+    // claim the frame holds 5 payload bytes when really 0
+    encoded[5] = 5;
+
+    DecodedFrame d = decodeFrame(encoded, n);
+    TEST_ASSERT_FALSE(d.ok);
+    TEST_ASSERT_EQUAL_UINT8(DECODE_BAD_LENGTH, d.errorCode);
+}
+
+// ----- Session key derivation -----
+
+void test_derive_session_key_layout() {
+    uint8_t key[16];
+    bool ok = deriveSessionKey("25B2303210", 10, /*ts=*/0x12345678ULL, key);
+    TEST_ASSERT_TRUE(ok);
+    // [0..7] = even bytes of MD5("lepucloud")
+    static const uint8_t kSalt[8] = {0xc2, 0xcf, 0xda, 0xd8, 0xa8, 0xf7, 0xc4, 0x35};
+    TEST_ASSERT_EQUAL_UINT8_ARRAY(kSalt, key, 8);
+    // [8..11] = "25B2"
+    TEST_ASSERT_EQUAL_UINT8('2', key[8]);
+    TEST_ASSERT_EQUAL_UINT8('5', key[9]);
+    TEST_ASSERT_EQUAL_UINT8('B', key[10]);
+    TEST_ASSERT_EQUAL_UINT8('2', key[11]);
+    // [12..15] = ts >> 0,1,2,3 (NOT byte-extract — quirky AAR shift)
+    for (int n = 0; n < 4; n++) {
+        TEST_ASSERT_EQUAL_UINT8(static_cast<uint8_t>((0x12345678ULL >> n) & 0xFF), key[12 + n]);
+    }
+}
+
+void test_derive_session_key_short_serial_fails() {
+    uint8_t key[16];
+    bool ok = deriveSessionKey("AB", 2, 0, key);
+    TEST_ASSERT_FALSE(ok);
+}
+
+// ----- parseGetInfoReply: validated against captured ViHealth snoop -----
+
+// Captured 2026-04-27 from a real ViHealth-app GET_INFO response on this user's
+// T8520. Full notify frame; payload is bytes [7..-1] (60 bytes).
+static const char kSnoopGetInfoFrame[] =
+    "a5e11e01023c00420005000102000000324430313030303201400852160100"
+    "ea07041b0b0808e007000000000a3235423233303332313000000000000000"
+    "000000000016";
+
+void test_parse_get_info_extracts_serial_and_firmware() {
+    uint8_t frame[128];
+    size_t fn = fromHex(kSnoopGetInfoFrame, frame, sizeof(frame));
+    DecodedFrame d = decodeFrame(frame, fn);
+    TEST_ASSERT_TRUE(d.ok);
+    TEST_ASSERT_EQUAL_UINT8(OP_GET_INFO, d.opcode);
+    TEST_ASSERT_EQUAL_size_t(60, d.payloadLen);
+
+    DeviceInfo info = parseGetInfoReply(frame + d.payloadOffset, d.payloadLen);
+    TEST_ASSERT_TRUE(info.ok);
+    TEST_ASSERT_EQUAL_STRING("2D010002", info.firmwareVersion);
+    TEST_ASSERT_EQUAL_STRING("25B2303210", info.serialNumber);
+}
+
+void test_parse_get_info_too_short_returns_not_ok() {
+    uint8_t tiny[10] = {0};
+    DeviceInfo info = parseGetInfoReply(tiny, sizeof(tiny));
+    TEST_ASSERT_FALSE(info.ok);
+}
+
+// ----- READ_FILE_START / DATA payload builders -----
+
+void test_build_read_file_start_payload_filename_and_type() {
+    uint8_t out[20];
+    const char* fn = "20260427213521";  // 14 chars, typical T8520 filename
+    bool ok = buildReadFileStartPayload(fn, strlen(fn), 0, out, sizeof(out));
+    TEST_ASSERT_TRUE(ok);
+    TEST_ASSERT_EQUAL_STRING_LEN(fn, reinterpret_cast<const char*>(out), 14);
+    // Bytes 14..15 must be null-pad
+    TEST_ASSERT_EQUAL_UINT8(0, out[14]);
+    TEST_ASSERT_EQUAL_UINT8(0, out[15]);
+    // Bytes 16..19 = file_type u32 LE
+    TEST_ASSERT_EQUAL_UINT8(0, out[16]);
+    TEST_ASSERT_EQUAL_UINT8(0, out[17]);
+    TEST_ASSERT_EQUAL_UINT8(0, out[18]);
+    TEST_ASSERT_EQUAL_UINT8(0, out[19]);
+}
+
+void test_build_read_file_data_payload_offset_le() {
+    uint8_t out[8];
+    bool ok = buildReadFileDataPayload(0x12345678, out, sizeof(out));
+    TEST_ASSERT_TRUE(ok);
+    TEST_ASSERT_EQUAL_UINT8(0x78, out[0]);
+    TEST_ASSERT_EQUAL_UINT8(0x56, out[1]);
+    TEST_ASSERT_EQUAL_UINT8(0x34, out[2]);
+    TEST_ASSERT_EQUAL_UINT8(0x12, out[3]);
+}
+
+void test_build_read_file_data_payload_outcap_too_small() {
+    uint8_t out[3];
+    bool ok = buildReadFileDataPayload(0, out, sizeof(out));
+    TEST_ASSERT_FALSE(ok);
+}
+
+// ----- File list iteration -----
+
+void test_file_list_parses_two_entries() {
+    // count=2, two 16-byte slots: "20260427105949" + 2 nulls, "20260427110015" + 2 nulls
+    uint8_t buf[33];
+    buf[0] = 2;
+    const char* a = "20260427105949";
+    const char* b = "20260427110015";
+    memset(buf + 1, 0, 32);
+    memcpy(buf + 1, a, strlen(a));
+    memcpy(buf + 17, b, strlen(b));
+
+    FileListIter it = beginFileList(buf, sizeof(buf));
+    TEST_ASSERT_EQUAL_UINT8(2, it.count);
+
+    char name[MAX_FILE_NAME + 2];
+    TEST_ASSERT_TRUE(nextFilename(it, name));
+    TEST_ASSERT_EQUAL_STRING("20260427105949", name);
+    TEST_ASSERT_TRUE(nextFilename(it, name));
+    TEST_ASSERT_EQUAL_STRING("20260427110015", name);
+    TEST_ASSERT_FALSE(nextFilename(it, name));
+}
+
+int main(int, char**) {
+    UNITY_BEGIN();
+    RUN_TEST(test_crc_get_info_seq2_matches_snoop);
+    RUN_TEST(test_crc_set_utc_time_seq1_matches_snoop);
+    RUN_TEST(test_crc_keepalive_matches_snoop);
+    RUN_TEST(test_crc_handshake_matches_snoop);
+    RUN_TEST(test_crc_auth_with_encrypted_payload_matches_snoop);
+    RUN_TEST(test_encode_get_info_matches_snoop);
+    RUN_TEST(test_encode_set_utc_time_matches_snoop);
+    RUN_TEST(test_encode_large_payload_uses_little_endian_length);
+    RUN_TEST(test_encode_returns_zero_when_outcap_too_small);
+    RUN_TEST(test_decode_roundtrip_with_payload);
+    RUN_TEST(test_decode_rejects_bad_lead);
+    RUN_TEST(test_decode_rejects_bad_complement);
+    RUN_TEST(test_decode_rejects_bad_crc);
+    RUN_TEST(test_decode_rejects_short_frame);
+    RUN_TEST(test_decode_rejects_length_mismatch);
+    RUN_TEST(test_derive_session_key_layout);
+    RUN_TEST(test_derive_session_key_short_serial_fails);
+    RUN_TEST(test_parse_get_info_extracts_serial_and_firmware);
+    RUN_TEST(test_parse_get_info_too_short_returns_not_ok);
+    RUN_TEST(test_build_read_file_start_payload_filename_and_type);
+    RUN_TEST(test_build_read_file_data_payload_offset_le);
+    RUN_TEST(test_build_read_file_data_payload_outcap_too_small);
+    RUN_TEST(test_file_list_parses_two_entries);
+    return UNITY_END();
+}


### PR DESCRIPTION
## Summary

Adds `OxyIIProtocol.h` — the application-layer protocol Wellue uses on the **T8520 / O2Ring-S** ring. This is the format Sleep's direct-BLE puller (`pull_v2.py`) cracked yesterday in the admin/sleep repo, validated against ViHealth-app HCI snoop frames.

**This is distinct from the legacy O2Ring protocol** (`O2RingProtocol.h`). Different service UUID (`E8FB0001-…` vs `14839ac4-…`), different lead byte (`0xA5` vs `0xAA`), different CRC scope (whole frame vs header-only), opcode-complement validation, and an AES-128 session key derived from a quirky shift-of-timestamp algorithm. Treating them as parallel device-classes is simpler than retrofitting the legacy module.

## What's in scope

Pure-C++, header-only, no Arduino / FreeRTOS / ESP-IDF deps:
- `crc8()` — poly 0x07, validated byte-for-byte against 5 captured ViHealth snoop frames
- `encodeFrame()` / `decodeFrame()` — full envelope validation; every error-code branch tested
- `deriveSessionKey()` — exact port of `doaj.doaf.doa(String)` from the lepu-blepro AAR; even-byte bytes of `MD5("lepucloud")` pre-computed as a constant so the protocol layer stays mbedtls-independent
- `parseGetInfoReply()` — extracts SN + firmware version from the 60-byte E1 reply; validated against a real GET_INFO payload from this user's T8520 (sn=`25B2303210`, fw=`2D010002`)
- `buildReadFileStartPayload()` / `buildReadFileDataPayload()`
- `FileListIter` for the GET_FILE_LIST reply

## What's out of scope (deferred)

- **AES-128/ECB/PKCS7 wrap/unwrap** — uses mbedtls on-device, so it'll live in a separate translation unit gated by the platform. Frame layer is fully testable on the host without it.
- **Orchestrator (`O2RingOxyIISync.cpp`)** — NimBLE connect, MTU negotiation, command flow, file buffering in PSRAM, upload to API. Separate PR; consumes the primitives this one adds.

## Test plan

- [x] `pio test -e native -f test_oxyii_protocol` → 23 cases pass
- [x] `pio test -e native` (full suite) → 199 cases pass (was 176; +23 new)
- [x] No legacy O2Ring code touched — existing 176 tests pass unchanged
- [ ] Hardware test deferred — the orchestrator PR will be the first user-at-desk validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)