### PR TITLE
feat(o2ring): on-demand sync button + end-to-end OxyII pull working on ring hardware

### DIFF
--- a/include/CpapWebServer.h
+++ b/include/CpapWebServer.h
@@ -65,6 +65,7 @@ private:
 
 #ifdef ENABLE_O2RING_SYNC
     void handleApiO2RingStatus();
+    void handleTriggerO2RingSync();
 #endif
 
 #ifdef ENABLE_OTA_UPDATES

--- a/include/O2RingFileSink.h
+++ b/include/O2RingFileSink.h
@@ -1,0 +1,38 @@
+#ifndef O2RING_FILE_SINK_H
+#define O2RING_FILE_SINK_H
+
+#include <Arduino.h>
+#include <cstdint>
+
+// Streaming destination for an O2Ring file pull. The orchestrator hands BLE
+// chunks (~240 bytes each) to writeChunk() as they arrive, instead of
+// buffering the whole file in RAM first. This lets us pull 80+ KB files
+// even when ESP32 max-contiguous-heap is only 30 KB at sync time.
+//
+// Lifecycle per file:
+//   begin(name, totalSize) → writeChunk(...) × N → finalize(ok)
+//
+// One sink instance can be reused across multiple files in a single sync
+// run; the orchestrator calls begin/finalize once per file. Implementations
+// are responsible for cleaning up partial data on finalize(false).
+class O2RingFileSink {
+public:
+    virtual ~O2RingFileSink() = default;
+
+    // Called before any chunks. totalSize comes from F2's reply (file size
+    // advertised by the ring). Return false to abort this file's pull;
+    // finalize() will not be called in that case.
+    virtual bool begin(const String& filename, uint32_t totalSize) = 0;
+
+    // Called once per F3 reply chunk. Return false to abort the pull;
+    // finalize(false) will be called for cleanup.
+    virtual bool writeChunk(const uint8_t* data, size_t len) = 0;
+
+    // Called exactly once after begin() returned true, regardless of
+    // success. ok=true means all chunks were delivered and matched the
+    // advertised size; ok=false means abort/error and any partial output
+    // should be cleaned up.
+    virtual void finalize(bool ok) = 0;
+};
+
+#endif  // O2RING_FILE_SINK_H

--- a/include/O2RingOxyIISync.h
+++ b/include/O2RingOxyIISync.h
@@ -7,6 +7,7 @@
 #include <vector>
 
 #include "IBleClient.h"
+#include "O2RingFileSink.h"
 #include "O2RingState.h"
 
 // Outcome of a sync run. Distinct values per state-machine step so the
@@ -39,21 +40,18 @@ struct OxyIIConfig {
 // drives the full state machine (scan → connect → MTU → command flow → per-
 // file pull → disconnect) and returns a terminal result.
 //
-// Persistence of pulled file bytes is delegated to onFileComplete: the
-// orchestrator buffers each file in RAM (max ≤32 KB observed in the wild)
-// and hands the buffer + filename to the callback when 0xF4 arrives. The
-// callback returns true on success (file is then marked synced in dedup
-// state); false leaves the filename un-synced for the next attempt.
+// Persistence of pulled file bytes is delegated to a streaming O2RingFileSink:
+// each F3 chunk is handed to sink.writeChunk() as it arrives, so the
+// orchestrator never buffers more than one chunk (~240 bytes) in RAM. The
+// sink is responsible for whatever durable storage / upload is needed and
+// indicates per-file success via finalize(ok). A sink returning false from
+// begin() or writeChunk() leaves the filename un-synced for the next attempt.
 class O2RingOxyIISync {
 public:
-    using OnFileComplete = std::function<bool(const String& filename,
-                                              const uint8_t* data,
-                                              size_t len)>;
-
     O2RingOxyIISync(IBleClient& ble,
                     O2RingState& state,
                     const OxyIIConfig& config,
-                    OnFileComplete onFileComplete);
+                    O2RingFileSink& sink);
 
     O2RingSyncResult run();
 
@@ -67,7 +65,7 @@ private:
     IBleClient&       _ble;
     O2RingState&      _state;
     OxyIIConfig       _config;
-    OnFileComplete    _onFileComplete;
+    O2RingFileSink&   _sink;
     uint8_t           _seq = 0;
     uint8_t           _sessionKey[16] = {0};
     bool              _sessionKeyDerived = false;

--- a/include/O2RingOxyIISync.h
+++ b/include/O2RingOxyIISync.h
@@ -81,13 +81,22 @@ private:
     // Send-then-receive a single command. Returns the decoded reply bytes
     // (payload only, NOT the wire envelope) on success, or empty on any
     // failure. seq is bumped automatically.
+    //
+    // expectReply=false: send fire-and-forget (no reply timeout, no decode).
+    // Used for 0xFF AUTH which the ring acknowledges silently — no reply is
+    // ever sent (confirmed across pair / sync / our own snoops). pull_v2.py
+    // mirrors this with a 1-second implicit pause; we use postSendDelayMs.
     bool sendCommand(uint8_t opcode, const uint8_t* payload, size_t payloadLen,
-                     uint8_t* outPayload, size_t outCap, size_t& outLen);
+                     uint8_t* outPayload, size_t outCap, size_t& outLen,
+                     bool expectReply = true,
+                     uint32_t postSendDelayMs = 0);
 
     // Like sendCommand but encrypts the payload with _sessionKey before send.
     // Used for 0xFF (AUTH) and 0xF2 (READ_FILE_START).
     bool sendEncryptedCommand(uint8_t opcode, const uint8_t* payload, size_t payloadLen,
-                              uint8_t* outPayload, size_t outCap, size_t& outLen);
+                              uint8_t* outPayload, size_t outCap, size_t& outLen,
+                              bool expectReply = true,
+                              uint32_t postSendDelayMs = 0);
 
     // Pull one file via the F2/F3-loop/F4 sequence. Returns true if all bytes
     // arrived and onFileComplete returned true; false on any failure.

--- a/include/SMBUploader.h
+++ b/include/SMBUploader.h
@@ -173,6 +173,22 @@ public:
      * @return true if upload successful, false otherwise
      */
     bool uploadRawBuffer(const String& remotePath, const uint8_t* data, size_t len);
+
+    /**
+     * Streaming write API — open a remote file once, write chunks as they
+     * arrive, then close. Used by the O2Ring sync sink so we never have to
+     * buffer a whole BLE-pulled file in RAM.
+     *
+     * Lifecycle:
+     *   smb2fh* fh = openForWrite(remotePath);   // nullptr on failure
+     *   while (more) writeStream(fh, chunk, len);
+     *   closeStream(fh);                          // always pair with open
+     *   if (failed) unlinkRemote(remotePath);     // best-effort cleanup
+     */
+    struct smb2fh* openForWrite(const String& remotePath);
+    bool writeStream(struct smb2fh* fh, const uint8_t* data, size_t len);
+    void closeStream(struct smb2fh* fh);
+    bool unlinkRemote(const String& remotePath);
 };
 
 #endif // ENABLE_SMB_UPLOAD

--- a/include/web_ui.h
+++ b/include/web_ui.h
@@ -98,6 +98,7 @@ nav button:hover:not(.act){background:#3a5a7e}
 <div class=row><span class=k>Result</span><span id=d-o2r-res class=v>—</span></div>
 <div class=row><span class=k>Files synced</span><span id=d-o2r-n class=v>—</span></div>
 <div class=row><span class=k>Last file on ring</span><span id=d-o2r-fn class=v>—</span></div>
+<div class=actions style="margin-top:10px"><button id=btn-o2r-sync class="btn bp" onclick=triggerO2RingSync()>&#128260; Sync Now</button></div>
 </div>
 </div>
 <div class=cards>
@@ -532,6 +533,16 @@ function triggerUpload(){
     toast(d.message||'Upload triggered.',mode);
   }).catch(function(){toast('Failed to trigger upload.','er');
   }).finally(function(){setTimeout(function(){b._busy=0;b.textContent='\u25b2 Trigger Upload';},700);});
+}
+function triggerO2RingSync(){
+  var b=document.getElementById('btn-o2r-sync');
+  if(!b||b._busy)return;b._busy=1;b.textContent='Triggering...';
+  fetch('/trigger-o2ring-sync',{cache:'no-store'}).then(function(r){return r.json();}).then(function(d){
+    var mode=d.status==='success'?'ok':d.status==='busy'||d.status==='disabled'?'warn':'er';
+    toast(d.message||'O2Ring sync triggered.',mode);
+    if(d.status==='success'){pollStatus();}
+  }).catch(function(){toast('Failed to trigger O2Ring sync.','er');
+  }).finally(function(){setTimeout(function(){b._busy=0;b.innerHTML='&#128260; Sync Now';},700);});
 }
 function softReboot(){
   var b=document.getElementById('btn-srb');

--- a/include/web_ui.h
+++ b/include/web_ui.h
@@ -5,6 +5,10 @@
 // All rendering is client-side JS. ESP32 only serves this once per page load,
 // then the browser polls /api/status, /api/logs, /api/config, /api/sd-activity.
 
+// String-literal concatenation lets us conditionally include OTA-only
+// markup at compile time. ENABLE_OTA_UPDATES and ENABLE_O2RING_SYNC are
+// mutually exclusive (per platformio.ini comment) — when O2Ring is built
+// in, OTA is off, and the OTA tab + panel + JS should not be served.
 static const char WEB_UI_HTML[] PROGMEM = R"HTMLEOF(<!DOCTYPE html><html><head>
 <title>CPAP Uploader</title><meta charset=utf-8>
 <meta name=viewport content="width=device-width,initial-scale=1">
@@ -70,8 +74,12 @@ nav button:hover:not(.act){background:#3a5a7e}
 <button id=t-logs onclick="tab('logs')">Logs</button>
 <button id=t-cfg onclick="tab('cfg')">Config</button>
 <button id=t-mon onclick="tab('mon')">Monitor</button>
-<button id=t-ota onclick="tab('ota')">OTA</button>
-</nav>
+)HTMLEOF"
+#ifdef ENABLE_OTA_UPDATES
+R"HTMLOTA(<button id=t-ota onclick="tab('ota')">OTA</button>
+)HTMLOTA"
+#endif
+R"HTMLEOF(</nav>
 
 <!-- DASHBOARD -->
 <div id=dash class="page on">
@@ -188,7 +196,9 @@ nav button:hover:not(.act){background:#3a5a7e}
 </div>
 </div>
 
-<!-- OTA -->
+)HTMLEOF"
+#ifdef ENABLE_OTA_UPDATES
+R"HTMLOTA(<!-- OTA -->
 <div id=ota class=page>
 <div class=wb><h3>WARNING</h3><ul>
 <li><strong>Do not power off</strong> during update</li>
@@ -215,6 +225,9 @@ nav button:hover:not(.act){background:#3a5a7e}
 </div>
 </div>
 </div>
+)HTMLOTA"
+#endif
+R"HTMLEOF(
 </div>
 
 <div id=toast class=toast></div>
@@ -224,8 +237,10 @@ nav button:hover:not(.act){background:#3a5a7e}
 var cfg={},monPoll=null,logPoll=null,curTab='dash';
 function tab(t){
   ['dash','logs','cfg','mon','ota'].forEach(function(x){
-    document.getElementById(x).classList.toggle('on',x===t);
-    document.getElementById('t-'+x).classList.toggle('act',x===t);
+    var p=document.getElementById(x);
+    var b=document.getElementById('t-'+x);
+    if(p)p.classList.toggle('on',x===t);
+    if(b)b.classList.toggle('act',x===t);
   });
   curTab=t;
   if(t==='logs'){startLogPoll();}else{stopLogPoll();}
@@ -562,7 +577,9 @@ function resetState(){
   }).finally(function(){setTimeout(function(){b._busy=0;b.textContent='Reset State';},1000);});
 }
 
-var otaBusy=false;
+)HTMLEOF"
+#ifdef ENABLE_OTA_UPDATES
+R"HTMLOTA(var otaBusy=false;
 function setMsg(id,cls,msg){var e=document.getElementById(id);if(e){e.className='sm '+cls;e.textContent=msg;}}
 document.getElementById('f-up').addEventListener('submit',function(e){
   e.preventDefault();if(otaBusy)return;
@@ -587,6 +604,9 @@ function handleOtaResult(d,sid){
   if(d.success){setMsg(sid,'ok','Success! '+d.message);var t=30;var iv=setInterval(function(){t--;setMsg(sid,'ok','Redirecting in '+t+'s...');if(t<=0){clearInterval(iv);location.href='/';}},1000);}
   else setMsg(sid,'er','Failed: '+d.message);
 }
+)HTMLOTA"
+#endif
+R"HTMLEOF(
 
 loadCfg();
 startStatusPoll();

--- a/src/CpapWebServer.cpp
+++ b/src/CpapWebServer.cpp
@@ -15,6 +15,9 @@
 volatile bool g_triggerUploadFlag = false;
 volatile bool g_resetStateFlag = false;
 volatile bool g_softRebootFlag = false;
+#ifdef ENABLE_O2RING_SYNC
+volatile bool g_triggerO2RingSyncFlag = false;
+#endif
 
 // Monitoring trigger flags
 volatile bool g_monitorActivityFlag = false;
@@ -182,6 +185,10 @@ bool CpapWebServer::begin() {
         if (this->redirectToIpIfMdnsRequest()) return;
         this->handleApiO2RingStatus();
     });
+    server->on("/trigger-o2ring-sync", [this]() {
+        if (this->redirectToIpIfMdnsRequest()) return;
+        this->handleTriggerO2RingSync();
+    });
 #endif
 
 #ifdef ENABLE_OTA_UPDATES
@@ -213,6 +220,9 @@ bool CpapWebServer::begin() {
     LOG("[WebServer] Available endpoints:");
     LOG("[WebServer]   GET  /                  - Dashboard (HTML SPA)");
     LOG("[WebServer]   GET  /trigger-upload    - Force immediate upload");
+#ifdef ENABLE_O2RING_SYNC
+    LOG("[WebServer]   GET  /trigger-o2ring-sync - Force immediate O2Ring sync");
+#endif
     LOG("[WebServer]   GET  /status            - Status page (HTML)");
     LOG("[WebServer]   GET  /config            - Config page (HTML)");
     LOG("[WebServer]   GET  /logs              - Logs page (HTML)");
@@ -336,6 +346,32 @@ void CpapWebServer::handleTriggerUpload() {
 
 // GET /status - JSON status information (Legacy - Removed, use handleApiStatus)
 
+
+#ifdef ENABLE_O2RING_SYNC
+// GET /trigger-o2ring-sync - Force an immediate OxyII sync attempt
+void CpapWebServer::handleTriggerO2RingSync() {
+    LOG("[WebServer] O2Ring sync trigger requested via web interface");
+    addCorsHeaders(server);
+
+    if (!config || !config->isO2RingEnabled()) {
+        server->send(200, "application/json",
+            "{\"status\":\"disabled\",\"message\":\"O2Ring sync is disabled in config (O2RING_ENABLED).\"}");
+        return;
+    }
+
+    // Block while an upload task is running so we don't fight the FSM for
+    // ownership of the SD bus / WiFi/BT coex state mid-upload.
+    if (uploadTaskRunning) {
+        server->send(200, "application/json",
+            "{\"status\":\"busy\",\"message\":\"Upload in progress; try again after it completes.\"}");
+        return;
+    }
+
+    g_triggerO2RingSyncFlag = true;
+    server->send(200, "application/json",
+        "{\"status\":\"success\",\"message\":\"O2Ring sync triggered. Watch the dashboard for results.\"}");
+}
+#endif
 
 // GET /soft-reboot - Reboot immediately, skipping cold-boot delays
 void CpapWebServer::handleSoftReboot() {

--- a/src/Esp32BleClient.cpp
+++ b/src/Esp32BleClient.cpp
@@ -23,6 +23,33 @@ void Esp32BleClient::initStack() {
          (unsigned)ESP.getFreeHeap(), (unsigned)ESP.getMaxAllocHeap());
 }
 
+// Match the four OxyII-mode signatures pull_v2.py uses, in priority order.
+// The OxyII-mode advertisement rarely carries the OxyII service UUID; matching
+// only on that (the previous behavior) misses the ring almost every time.
+// Returns a static label naming which signature hit, or nullptr if none did.
+static const char* matchOxyIISignature(NimBLEAdvertisedDevice& d, const NimBLEUUID& target) {
+    // 1. Random Static address with prefix F3:7F:ED (post-reset address)
+    String addr = d.getAddress().toString().c_str();
+    addr.toUpperCase();
+    if (addr.startsWith("F3:7F:ED")) return "addr-prefix";
+    // 2. Manufacturer ID 0xF34E (OxyII-mode marker)
+    if (d.haveManufacturerData()) {
+        std::string m = d.getManufacturerData();
+        if (m.size() >= 2) {
+            uint16_t cid = (uint8_t)m[0] | ((uint16_t)(uint8_t)m[1] << 8);
+            if (cid == 0xF34E) return "manuf-id";
+        }
+    }
+    // 3. Local name starting with "S8-AW"
+    if (d.haveName()) {
+        std::string name = d.getName();
+        if (name.rfind("S8-AW", 0) == 0) return "name-prefix";
+    }
+    // 4. OxyII service UUID in advertisement (rare but cheap)
+    if (d.isAdvertisingService(target)) return "service-uuid";
+    return nullptr;
+}
+
 Esp32BleClient::Esp32BleClient()
     : client(nullptr), writeChar(nullptr), notifyChar(nullptr), _connected(false) {}
 
@@ -61,13 +88,16 @@ bool Esp32BleClient::connect(const String& serviceUuid, uint32_t scanSecs) {
     bool found = false;
     for (int i = 0; i < results.getCount(); i++) {
         NimBLEAdvertisedDevice d = results.getDevice(i);
-        if (d.isAdvertisingService(target)) {
+        const char* via = matchOxyIISignature(d, target);
+        if (via) {
             targetAddr = d.getAddress();
             found = true;
             _lastScanFound = true;
-            LOGF("[O2Ring BLE] Found device by service UUID: name=%s addr=%s",
+            LOGF("[O2Ring BLE] Found OxyII ring via %s: name=%s addr=%s rssi=%d",
+                 via,
                  d.haveName() ? d.getName().c_str() : "(unnamed)",
-                 d.getAddress().toString().c_str());
+                 d.getAddress().toString().c_str(),
+                 d.haveRSSI() ? d.getRSSI() : 0);
             break;
         }
     }

--- a/src/O2RingOxyIISync.cpp
+++ b/src/O2RingOxyIISync.cpp
@@ -136,58 +136,89 @@ bool O2RingOxyIISync::pullFile(const String& filename) {
              filename.c_str(), (unsigned)advertisedSize);
     }
 
-    // F3 loop — fetch chunks at increasing offsets until a chunk comes back
-    // shorter than the previous one (signaling end of file).
-    std::vector<uint8_t> fileBytes;
-    fileBytes.reserve(8 * 1024);   // initial guess; std::vector will grow if needed
+    // Pre-allocate the destination buffer once. Growing a std::vector
+    // incrementally (doubling on each push) fragments the heap and crashes
+    // with bad_alloc on ~80 KB files even when total free heap is sufficient.
+    // malloc() returns nullptr on failure (no exceptions in IDF) so we can
+    // bail gracefully if the file is too big for current heap fragmentation.
+    if (advertisedSize == 0) {
+        LOG_ERROR("[OxyII] F2 did not advertise file size — refusing pull");
+        return false;
+    }
+    uint8_t* fileBytes = (uint8_t*)malloc(advertisedSize);
+    if (!fileBytes) {
+#ifndef UNIT_TEST
+        LOG_ERRORF("[OxyII] malloc(%u) failed (free=%u, max_alloc=%u) — file too big for current heap",
+                   (unsigned)advertisedSize,
+                   (unsigned)ESP.getFreeHeap(),
+                   (unsigned)ESP.getMaxAllocHeap());
+#else
+        LOG_ERRORF("[OxyII] malloc(%u) failed — file too big for current heap",
+                   (unsigned)advertisedSize);
+#endif
+        return false;
+    }
 
+    // F3 loop — fetch chunks at increasing offsets until we've read
+    // advertisedSize bytes, or the ring sends an empty chunk (EOF).
     uint32_t offset = 0;
-    size_t   prevChunkLen = 0;
     bool     finished = false;
+    bool     ok = true;
 
     while (!finished) {
         uint8_t dataPayload[4];
         if (!OxyIIProtocol::buildReadFileDataPayload(offset, dataPayload, sizeof(dataPayload))) {
             LOG_ERROR("[OxyII] readFileData payload build failed");
-            return false;
+            ok = false;
+            break;
         }
         size_t chunkLen = 0;
         if (!sendCommand(OxyIIProtocol::OP_READ_FILE_DATA,
                          dataPayload, sizeof(dataPayload),
                          reply, sizeof(reply), chunkLen)) {
             LOG_ERRORF("[OxyII] readFileData failed at offset %u", (unsigned)offset);
-            return false;
-        }
-        if (chunkLen > 0) {
-            fileBytes.insert(fileBytes.end(), reply, reply + chunkLen);
-            offset += chunkLen;
+            ok = false;
+            break;
         }
         if (chunkLen == 0) {
-            // Empty chunk = EOF (matches pull_v2.py).
-            finished = true;
-        } else if (advertisedSize > 0 && offset >= advertisedSize) {
-            // Reached size advertised by F2 reply.
-            finished = true;
-        } else if (prevChunkLen != 0 && chunkLen < prevChunkLen) {
-            // Fallback when no advertised size: short-chunk = EOF.
+            finished = true;  // empty chunk = EOF
+            break;
+        }
+        if (offset + chunkLen > advertisedSize) {
+            LOG_ERRORF("[OxyII] chunk overrun: offset=%u + chunk=%u > advertised=%u",
+                       (unsigned)offset, (unsigned)chunkLen, (unsigned)advertisedSize);
+            ok = false;
+            break;
+        }
+        memcpy(fileBytes + offset, reply, chunkLen);
+        offset += chunkLen;
+        if (offset >= advertisedSize) {
             finished = true;
         }
-        prevChunkLen = chunkLen;
+    }
+
+    if (!ok) {
+        free(fileBytes);
+        return false;
     }
 
     // F4 — READ_FILE_END
     if (!sendCommand(OxyIIProtocol::OP_READ_FILE_END, nullptr, 0,
                      reply, sizeof(reply), replyLen)) {
         LOG_ERROR("[OxyII] readFileEnd failed");
+        free(fileBytes);
         return false;
     }
 
-    if (fileBytes.empty()) {
+    if (offset == 0) {
         LOG_ERROR("[OxyII] file pull produced zero bytes");
+        free(fileBytes);
         return false;
     }
 
-    if (!_onFileComplete(filename, fileBytes.data(), fileBytes.size())) {
+    bool callbackOk = _onFileComplete(filename, fileBytes, offset);
+    free(fileBytes);
+    if (!callbackOk) {
         LOG_ERRORF("[OxyII] onFileComplete returned false for %s", filename.c_str());
         return false;
     }

--- a/src/O2RingOxyIISync.cpp
+++ b/src/O2RingOxyIISync.cpp
@@ -36,8 +36,8 @@ size_t buildSetTimePayload(const struct tm& tm, uint8_t* out, size_t outCap) {
 O2RingOxyIISync::O2RingOxyIISync(IBleClient& ble,
                                   O2RingState& state,
                                   const OxyIIConfig& config,
-                                  OnFileComplete onFileComplete)
-    : _ble(ble), _state(state), _config(config), _onFileComplete(std::move(onFileComplete)) {}
+                                  O2RingFileSink& sink)
+    : _ble(ble), _state(state), _config(config), _sink(sink) {}
 
 bool O2RingOxyIISync::sendCommand(uint8_t opcode, const uint8_t* payload, size_t payloadLen,
                                    uint8_t* outPayload, size_t outCap, size_t& outLen,
@@ -136,26 +136,17 @@ bool O2RingOxyIISync::pullFile(const String& filename) {
              filename.c_str(), (unsigned)advertisedSize);
     }
 
-    // Pre-allocate the destination buffer once. Growing a std::vector
-    // incrementally (doubling on each push) fragments the heap and crashes
-    // with bad_alloc on ~80 KB files even when total free heap is sufficient.
-    // malloc() returns nullptr on failure (no exceptions in IDF) so we can
-    // bail gracefully if the file is too big for current heap fragmentation.
+    // Streaming destination: every F3 chunk is forwarded to the sink as it
+    // arrives — orchestrator never holds more than one chunk in RAM. This
+    // is essential for files larger than the largest contiguous heap block
+    // available at sync time (~30 KB observed; real files reach 80+ KB).
     if (advertisedSize == 0) {
         LOG_ERROR("[OxyII] F2 did not advertise file size — refusing pull");
         return false;
     }
-    uint8_t* fileBytes = (uint8_t*)malloc(advertisedSize);
-    if (!fileBytes) {
-#ifndef UNIT_TEST
-        LOG_ERRORF("[OxyII] malloc(%u) failed (free=%u, max_alloc=%u) — file too big for current heap",
-                   (unsigned)advertisedSize,
-                   (unsigned)ESP.getFreeHeap(),
-                   (unsigned)ESP.getMaxAllocHeap());
-#else
-        LOG_ERRORF("[OxyII] malloc(%u) failed — file too big for current heap",
-                   (unsigned)advertisedSize);
-#endif
+    if (!_sink.begin(filename, advertisedSize)) {
+        LOG_ERRORF("[OxyII] sink.begin failed for %s (size=%u)",
+                   filename.c_str(), (unsigned)advertisedSize);
         return false;
     }
 
@@ -190,7 +181,11 @@ bool O2RingOxyIISync::pullFile(const String& filename) {
             ok = false;
             break;
         }
-        memcpy(fileBytes + offset, reply, chunkLen);
+        if (!_sink.writeChunk(reply, chunkLen)) {
+            LOG_ERRORF("[OxyII] sink.writeChunk failed at offset %u", (unsigned)offset);
+            ok = false;
+            break;
+        }
         offset += chunkLen;
         if (offset >= advertisedSize) {
             finished = true;
@@ -198,7 +193,7 @@ bool O2RingOxyIISync::pullFile(const String& filename) {
     }
 
     if (!ok) {
-        free(fileBytes);
+        _sink.finalize(false);
         return false;
     }
 
@@ -206,22 +201,17 @@ bool O2RingOxyIISync::pullFile(const String& filename) {
     if (!sendCommand(OxyIIProtocol::OP_READ_FILE_END, nullptr, 0,
                      reply, sizeof(reply), replyLen)) {
         LOG_ERROR("[OxyII] readFileEnd failed");
-        free(fileBytes);
+        _sink.finalize(false);
         return false;
     }
 
     if (offset == 0) {
         LOG_ERROR("[OxyII] file pull produced zero bytes");
-        free(fileBytes);
+        _sink.finalize(false);
         return false;
     }
 
-    bool callbackOk = _onFileComplete(filename, fileBytes, offset);
-    free(fileBytes);
-    if (!callbackOk) {
-        LOG_ERRORF("[OxyII] onFileComplete returned false for %s", filename.c_str());
-        return false;
-    }
+    _sink.finalize(true);
 
     _lastSyncedCount++;
     _lastSyncedFilename = filename;

--- a/src/O2RingOxyIISync.cpp
+++ b/src/O2RingOxyIISync.cpp
@@ -40,7 +40,8 @@ O2RingOxyIISync::O2RingOxyIISync(IBleClient& ble,
     : _ble(ble), _state(state), _config(config), _onFileComplete(std::move(onFileComplete)) {}
 
 bool O2RingOxyIISync::sendCommand(uint8_t opcode, const uint8_t* payload, size_t payloadLen,
-                                   uint8_t* outPayload, size_t outCap, size_t& outLen) {
+                                   uint8_t* outPayload, size_t outCap, size_t& outLen,
+                                   bool expectReply, uint32_t postSendDelayMs) {
     uint8_t frame[OxyIIProtocol::FRAME_HEADER_LEN + 600 + 1];
     size_t frameLen = OxyIIProtocol::encodeFrame(opcode, payload, payloadLen,
                                                   _seq++, frame, sizeof(frame));
@@ -52,6 +53,12 @@ bool O2RingOxyIISync::sendCommand(uint8_t opcode, const uint8_t* payload, size_t
     if (!_ble.writeChunked(frame, frameLen)) {
         LOG_ERRORF("[OxyII] write failed for opcode 0x%02x", opcode);
         return false;
+    }
+
+    if (!expectReply) {
+        outLen = 0;
+        if (postSendDelayMs > 0) delay(postSendDelayMs);
+        return true;
     }
 
     uint8_t replyFrame[kNotifyBufCap];
@@ -80,7 +87,8 @@ bool O2RingOxyIISync::sendCommand(uint8_t opcode, const uint8_t* payload, size_t
 }
 
 bool O2RingOxyIISync::sendEncryptedCommand(uint8_t opcode, const uint8_t* payload, size_t payloadLen,
-                                            uint8_t* outPayload, size_t outCap, size_t& outLen) {
+                                            uint8_t* outPayload, size_t outCap, size_t& outLen,
+                                            bool expectReply, uint32_t postSendDelayMs) {
     if (!_sessionKeyDerived) {
         LOG_ERROR("[OxyII] sendEncryptedCommand before key derived");
         return false;
@@ -92,7 +100,8 @@ bool O2RingOxyIISync::sendEncryptedCommand(uint8_t opcode, const uint8_t* payloa
         LOG_ERROR("[OxyII] AES encrypt failed");
         return false;
     }
-    return sendCommand(opcode, cipher, cipherLen, outPayload, outCap, outLen);
+    return sendCommand(opcode, cipher, cipherLen, outPayload, outCap, outLen,
+                       expectReply, postSendDelayMs);
 }
 
 bool O2RingOxyIISync::pullFile(const String& filename) {
@@ -210,11 +219,16 @@ O2RingSyncResult O2RingOxyIISync::run() {
     uint8_t reply[kNotifyBufCap];
     size_t replyLen = 0;
 
-    // 0xFF AUTH — encrypted 16-byte payload (zeros are accepted)
+    // 0xFF AUTH — encrypted 16-byte payload (zeros are accepted).
+    // The ring never sends a reply for AUTH (confirmed across all snoops),
+    // so we send fire-and-forget and pause briefly to let the ring process
+    // before the next command. pull_v2.py uses a 1s reply_timeout for the
+    // same effect; 1000ms here matches.
     {
         uint8_t authPayload[16] = {0};
         if (!sendEncryptedCommand(OxyIIProtocol::OP_AUTH, authPayload, sizeof(authPayload),
-                                   reply, sizeof(reply), replyLen)) {
+                                   reply, sizeof(reply), replyLen,
+                                   /*expectReply=*/false, /*postSendDelayMs=*/1000)) {
             _ble.disconnect();
             return O2RingSyncResult::AUTH_FAILED;
         }

--- a/src/O2RingOxyIISync.cpp
+++ b/src/O2RingOxyIISync.cpp
@@ -105,8 +105,10 @@ bool O2RingOxyIISync::sendEncryptedCommand(uint8_t opcode, const uint8_t* payloa
 }
 
 bool O2RingOxyIISync::pullFile(const String& filename) {
-    // F2 — READ_FILE_START. Encrypted 20-byte payload: 16-byte filename slot
-    // (null-padded) + u32 LE file_type (0 = .dat / OXY).
+    // F2 — READ_FILE_START. PLAINTEXT 20-byte payload: 16-byte filename slot
+    // (null-padded) + u32 LE file_type (0 = .dat / OXY). Per the protocol
+    // walkthrough: "Only cmd=0xFF (auth) is AES-encrypted. Everything else
+    // (... READ_FILE_START / DATA / END, ...) is plaintext."
     uint8_t startPayload[20];
     if (!OxyIIProtocol::buildReadFileStartPayload(filename.c_str(), filename.length(),
                                                    /*fileType=*/0, startPayload, sizeof(startPayload))) {
@@ -116,10 +118,22 @@ bool O2RingOxyIISync::pullFile(const String& filename) {
 
     uint8_t reply[kNotifyBufCap];
     size_t replyLen = 0;
-    if (!sendEncryptedCommand(OxyIIProtocol::OP_READ_FILE_START,
-                               startPayload, sizeof(startPayload),
-                               reply, sizeof(reply), replyLen)) {
+    if (!sendCommand(OxyIIProtocol::OP_READ_FILE_START,
+                     startPayload, sizeof(startPayload),
+                     reply, sizeof(reply), replyLen)) {
         return false;
+    }
+    // Reply payload is u32-LE file size. Use it to bound the F3 loop so we
+    // don't rely solely on "shorter chunk = EOF" — which fails if the file
+    // is exactly one chunk long.
+    uint32_t advertisedSize = 0;
+    if (replyLen >= 4) {
+        advertisedSize = (uint32_t)reply[0]
+                       | ((uint32_t)reply[1] << 8)
+                       | ((uint32_t)reply[2] << 16)
+                       | ((uint32_t)reply[3] << 24);
+        LOGF("[OxyII] %s advertised size = %u bytes",
+             filename.c_str(), (unsigned)advertisedSize);
     }
 
     // F3 loop — fetch chunks at increasing offsets until a chunk comes back
@@ -148,11 +162,14 @@ bool O2RingOxyIISync::pullFile(const String& filename) {
             fileBytes.insert(fileBytes.end(), reply, reply + chunkLen);
             offset += chunkLen;
         }
-        // End-of-file signal: a chunk shorter than the previous one. The first
-        // short-or-equal chunk after at least one chunk closes the loop.
-        if (prevChunkLen != 0 && chunkLen < prevChunkLen) {
+        if (chunkLen == 0) {
+            // Empty chunk = EOF (matches pull_v2.py).
             finished = true;
-        } else if (chunkLen == 0) {
+        } else if (advertisedSize > 0 && offset >= advertisedSize) {
+            // Reached size advertised by F2 reply.
+            finished = true;
+        } else if (prevChunkLen != 0 && chunkLen < prevChunkLen) {
+            // Fallback when no advertised size: short-chunk = EOF.
             finished = true;
         }
         prevChunkLen = chunkLen;

--- a/src/SMBUploader.cpp
+++ b/src/SMBUploader.cpp
@@ -945,4 +945,56 @@ bool SMBUploader::uploadRawBuffer(const String& remotePath, const uint8_t* data,
     return true;
 }
 
+smb2fh* SMBUploader::openForWrite(const String& remotePath) {
+    if (!connected && !connect()) {
+        return nullptr;
+    }
+    String fullPath = smbBasePath.length() > 0
+                    ? smbBasePath + remotePath
+                    : remotePath;
+    if (fullPath.startsWith("/")) {
+        fullPath = fullPath.substring(1);
+    }
+    smb2fh* fh = smb2_open(smb2, fullPath.c_str(), O_WRONLY | O_CREAT | O_TRUNC);
+    if (!fh) {
+        LOGF("[SMB] openForWrite: open failed: %s", remotePath.c_str());
+    }
+    return fh;
+}
+
+bool SMBUploader::writeStream(smb2fh* fh, const uint8_t* data, size_t len) {
+    if (!fh || !connected) return false;
+    size_t written = 0;
+    while (written < len) {
+        size_t chunk = (len - written) < 4096 ? (len - written) : 4096;
+        int n = smb2_write(smb2, fh, (uint8_t*)data + written, chunk);
+        if (n <= 0) {
+            LOGF("[SMB] writeStream: write error at offset %u", (unsigned)written);
+            return false;
+        }
+        written += (size_t)n;
+    }
+    return true;
+}
+
+void SMBUploader::closeStream(smb2fh* fh) {
+    if (fh && smb2) smb2_close(smb2, fh);
+}
+
+bool SMBUploader::unlinkRemote(const String& remotePath) {
+    if (!connected) return false;
+    String fullPath = smbBasePath.length() > 0
+                    ? smbBasePath + remotePath
+                    : remotePath;
+    if (fullPath.startsWith("/")) {
+        fullPath = fullPath.substring(1);
+    }
+    int rc = smb2_unlink(smb2, fullPath.c_str());
+    if (rc != 0) {
+        LOGF("[SMB] unlinkRemote: failed for %s (rc=%d)", remotePath.c_str(), rc);
+        return false;
+    }
+    return true;
+}
+
 #endif // ENABLE_SMB_UPLOAD

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -833,33 +833,93 @@ void handleMonitoring() {
 }
 
 #ifdef ENABLE_O2RING_SYNC
-// Handoff for each pulled file: SMB-upload it under
-// /<O2RingPath>/<deviceSegment>/<filename>.dat. Returns true on success;
-// orchestrator only marks the filename as synced when this returns true.
-static bool uploadO2RingFile(const String& filename, const uint8_t* data, size_t len) {
 #ifdef ENABLE_SMB_UPLOAD
-    SMBUploader smb(config.getEndpoint(),
-                    config.getEndpointUser(),
-                    config.getEndpointPassword());
-    if (!smb.begin()) {
-        LOG_ERROR("[OxyII FSM] SMB connect failed");
-        return false;
+// Streaming SMB sink for O2Ring file pulls. The orchestrator hands one
+// BLE chunk at a time to writeChunk(); we forward straight to smb2_write,
+// so peak RAM is one chunk (~240 B) per file regardless of file size.
+// Heap fragmentation no longer caps file size — we tested this against
+// 80+ KB recordings that the buffer-then-upload path could not fit.
+class O2RingSMBStreamingSink : public O2RingFileSink {
+public:
+    O2RingSMBStreamingSink()
+        : _smb(config.getEndpoint(),
+               config.getEndpointUser(),
+               config.getEndpointPassword()) {}
+
+    ~O2RingSMBStreamingSink() override {
+        if (_fh) _smb.closeStream(_fh);
+        if (_smbBegan) _smb.end();
     }
-    String dir = "/" + config.getO2RingPath() + "/" + config.getDeviceSegment();
-    smb.createDirectory(dir);
-    String remotePath = dir + "/" + filename + ".dat";
-    bool uploaded = smb.uploadRawBuffer(remotePath, data, len);
-    smb.end();
-    if (!uploaded) {
-        LOG_ERROR("[OxyII FSM] SMB upload failed");
-        return false;
+
+    bool begin(const String& filename, uint32_t totalSize) override {
+        if (!_smbBegan) {
+            if (!_smb.begin()) {
+                LOG_ERROR("[OxyII FSM] SMB connect failed");
+                return false;
+            }
+            _smbBegan = true;
+        }
+        String dir = "/" + config.getO2RingPath() + "/" + config.getDeviceSegment();
+        _smb.createDirectory(dir);
+        _currentRemotePath = dir + "/" + filename + ".dat";
+        _fh = _smb.openForWrite(_currentRemotePath);
+        if (!_fh) {
+            LOG_ERRORF("[OxyII FSM] SMB open-for-write failed: %s",
+                       _currentRemotePath.c_str());
+            return false;
+        }
+        LOGF("[OxyII FSM] streaming %s (%u bytes) -> %s",
+             filename.c_str(), (unsigned)totalSize, _currentRemotePath.c_str());
+        _bytesWritten = 0;
+        return true;
     }
-    return true;
+
+    bool writeChunk(const uint8_t* data, size_t len) override {
+        if (!_fh) return false;
+        if (!_smb.writeStream(_fh, data, len)) {
+            return false;
+        }
+        _bytesWritten += len;
+        return true;
+    }
+
+    void finalize(bool ok) override {
+        if (_fh) {
+            _smb.closeStream(_fh);
+            _fh = nullptr;
+        }
+        if (!ok && _currentRemotePath.length() > 0) {
+            // Best-effort cleanup of the partial file. Failures are logged
+            // by SMBUploader but do not block the sync run.
+            _smb.unlinkRemote(_currentRemotePath);
+            LOGF("[OxyII FSM] cleaned up partial %s", _currentRemotePath.c_str());
+        } else if (ok) {
+            LOGF("[OxyII FSM] streamed %u bytes to %s",
+                 (unsigned)_bytesWritten, _currentRemotePath.c_str());
+        }
+        _currentRemotePath = "";
+        _bytesWritten = 0;
+    }
+
+private:
+    SMBUploader   _smb;
+    bool          _smbBegan = false;
+    smb2fh*       _fh = nullptr;
+    String        _currentRemotePath;
+    size_t        _bytesWritten = 0;
+};
 #else
-    LOG_WARN("[OxyII FSM] No upload backend compiled in; discarding file");
-    return false;
+// No upload backend compiled in — sink does nothing and reports failure.
+class O2RingSMBStreamingSink : public O2RingFileSink {
+public:
+    bool begin(const String&, uint32_t) override {
+        LOG_WARN("[OxyII FSM] No upload backend compiled in; rejecting file");
+        return false;
+    }
+    bool writeChunk(const uint8_t*, size_t) override { return false; }
+    void finalize(bool) override {}
+};
 #endif
-}
 
 void handleO2RingSync() {
     // O2RING_DEVICE_NAME is no longer used as a scan filter (we filter by
@@ -877,7 +937,8 @@ void handleO2RingSync() {
     syncCfg.mtu = 247;
     syncCfg.cmdTimeoutMs = 5000;
 
-    O2RingOxyIISync sync(bleClient, state, syncCfg, uploadO2RingFile);
+    O2RingSMBStreamingSink sink;
+    O2RingOxyIISync sync(bleClient, state, syncCfg, sink);
     O2RingSyncResult result = sync.run();
 
     switch (result) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -115,6 +115,9 @@ bool g_debugMode = false;
 // External trigger flags (defined in WebServer.cpp)
 extern volatile bool g_triggerUploadFlag;
 extern volatile bool g_resetStateFlag;
+#ifdef ENABLE_O2RING_SYNC
+extern volatile bool g_triggerO2RingSyncFlag;
+#endif
 
 // Monitoring trigger flags (defined in WebServer.cpp)
 extern volatile bool g_monitorActivityFlag;
@@ -1029,6 +1032,19 @@ void loop() {
         uploadCycleHadTimeout = false;
         transitionTo(UploadState::ACQUIRING);
     }
+
+#ifdef ENABLE_O2RING_SYNC
+    // O2Ring sync trigger — jump straight into O2RING_SYNC, bypassing any
+    // remaining cooldown. Blocked while an upload task is running so the FSM
+    // can finish releasing the SD bus first. The trigger endpoint already
+    // gates on isO2RingEnabled(), so no need to re-check here.
+    if (g_triggerO2RingSyncFlag && !uploadTaskRunning &&
+        currentState != UploadState::O2RING_SYNC) {
+        LOG("=== O2Ring Sync Triggered via Web Interface ===");
+        g_triggerO2RingSyncFlag = false;
+        transitionTo(UploadState::O2RING_SYNC);
+    }
+#endif
     
     // Check for monitoring triggers
     if (g_monitorActivityFlag) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -27,6 +27,7 @@ bool g_heapRecoveryBoot = false;
 #ifdef ENABLE_O2RING_SYNC
 #include "O2RingOxyIISync.h"
 #include "O2RingState.h"
+#include "O2RingStatus.h"
 #ifdef ENABLE_SMB_UPLOAD
 #include "SMBUploader.h"
 #endif
@@ -940,6 +941,20 @@ void handleO2RingSync() {
     O2RingSMBStreamingSink sink;
     O2RingOxyIISync sync(bleClient, state, syncCfg, sink);
     O2RingSyncResult result = sync.run();
+
+    // Persist the outcome so the dashboard's O2Ring Sync card has fresh
+    // data. Use recordPreservingFilename for early-failure paths (no INFO
+    // yet, no file list yet); otherwise record with the most recent
+    // filename the orchestrator pulled.
+    O2RingStatus statusRec;
+    statusRec.load();
+    if (result == O2RingSyncResult::OK) {
+        statusRec.record((int)result, (uint16_t)sync.lastSyncedCount(),
+                         sync.lastSyncedFilename());
+    } else {
+        statusRec.recordPreservingFilename((int)result);
+    }
+    statusRec.save();
 
     switch (result) {
         case O2RingSyncResult::OK:

--- a/test/test_oxyii_sync/test_oxyii_sync.cpp
+++ b/test/test_oxyii_sync/test_oxyii_sync.cpp
@@ -81,9 +81,12 @@ std::vector<uint8_t> buildFileListReply(const std::vector<const char*>& names) {
 
 // Set up the canonical opening exchange (everything before GET_FILE_LIST).
 // Tests append additional replies (file-list, F2/F3/F4) on top.
+//
+// NOTE: AUTH (0xFF) is sent fire-and-forget — the ring never replies to it
+// (confirmed across pair / sync / our snoops; see oxyii_protocol.py and
+// pull_v2.py). So we DO NOT enqueue an AUTH reply here.
 void enqueueOpeningExchange(MockBleClient& mock, const char* sn = "T8520TEST",
                              const char* fw = "2D010002") {
-    mock.enqueueResponse(buildEmptyReply(OP_AUTH));
     mock.enqueueResponse(buildEmptyReply(OP_KEEPALIVE));
     mock.enqueueResponse(buildEmptyReply(OP_SET_UTC_TIME));
     mock.enqueueResponse(buildEmptyReply(OP_HANDSHAKE));
@@ -267,16 +270,25 @@ void test_mtu_negotiation_below_target_returns_mtu_failed() {
     TEST_ASSERT_EQUAL_INT((int)O2RingSyncResult::MTU_FAILED, (int)sync.run());
 }
 
-void test_auth_reply_missing_returns_auth_failed() {
+void test_auth_no_reply_proceeds_to_keepalive() {
+    // AUTH (0xFF) is fire-and-forget — the ring never sends an AUTH reply.
+    // With no responses queued at all, the orchestrator should successfully
+    // send AUTH (no reply expected) and then fail at the KEEPALIVE step
+    // which DOES expect a reply. This pins the new contract: AUTH never
+    // returns AUTH_FAILED for "missing reply" because no reply is ever
+    // expected.
     MockBleClient mock;
     O2RingState state;
     state.load();
-    // Don't enqueue any responses — first sendCommand (AUTH) gets nothing.
 
     auto onComplete = [&](const String&, const uint8_t*, size_t) { return true; };
     O2RingOxyIISync sync(mock, state, defaultConfig(), onComplete);
 
-    TEST_ASSERT_EQUAL_INT((int)O2RingSyncResult::AUTH_FAILED, (int)sync.run());
+    TEST_ASSERT_EQUAL_INT((int)O2RingSyncResult::HANDSHAKE_FAILED, (int)sync.run());
+    // Confirm AUTH was actually written despite no reply.
+    TEST_ASSERT_TRUE(mock.writeHistory.size() >= 2);
+    TEST_ASSERT_EQUAL_HEX8(OxyIIProtocol::OP_AUTH, mock.writeHistory[0][1]);
+    TEST_ASSERT_EQUAL_HEX8(OxyIIProtocol::OP_KEEPALIVE, mock.writeHistory[1][1]);
 }
 
 void test_get_info_reply_with_no_serial_returns_get_info_failed() {
@@ -284,7 +296,7 @@ void test_get_info_reply_with_no_serial_returns_get_info_failed() {
     O2RingState state;
     state.load();
 
-    mock.enqueueResponse(buildEmptyReply(OP_AUTH));
+    // AUTH is fire-and-forget — no reply enqueued.
     mock.enqueueResponse(buildEmptyReply(OP_KEEPALIVE));
     mock.enqueueResponse(buildEmptyReply(OP_SET_UTC_TIME));
     mock.enqueueResponse(buildEmptyReply(OP_HANDSHAKE));
@@ -396,7 +408,7 @@ int main(int, char**) {
     RUN_TEST(test_connect_fails_returns_connect_failed_when_device_found);
     RUN_TEST(test_connect_fails_returns_no_device_found_when_scan_empty);
     RUN_TEST(test_mtu_negotiation_below_target_returns_mtu_failed);
-    RUN_TEST(test_auth_reply_missing_returns_auth_failed);
+    RUN_TEST(test_auth_no_reply_proceeds_to_keepalive);
     RUN_TEST(test_get_info_reply_with_no_serial_returns_get_info_failed);
     RUN_TEST(test_file_list_missing_returns_file_list_failed);
     RUN_TEST(test_file_transfer_disconnect_mid_pull_returns_file_transfer_failed);

--- a/test/test_oxyii_sync/test_oxyii_sync.cpp
+++ b/test/test_oxyii_sync/test_oxyii_sync.cpp
@@ -52,6 +52,18 @@ std::vector<uint8_t> buildEmptyReply(uint8_t opcode) {
     return buildFrame(opcode, nullptr, 0);
 }
 
+// READ_FILE_START reply payload is u32-LE total file size. The orchestrator
+// uses this to bound the F3 loop and pre-allocate the destination buffer.
+std::vector<uint8_t> buildReadFileStartReply(uint32_t advertisedSize) {
+    uint8_t payload[4] = {
+        static_cast<uint8_t>(advertisedSize & 0xFF),
+        static_cast<uint8_t>((advertisedSize >> 8) & 0xFF),
+        static_cast<uint8_t>((advertisedSize >> 16) & 0xFF),
+        static_cast<uint8_t>((advertisedSize >> 24) & 0xFF),
+    };
+    return buildFrame(OP_READ_FILE_START, payload, sizeof(payload));
+}
+
 // Build a 60-byte GET_INFO reply payload with a known serial + firmware.
 std::vector<uint8_t> buildGetInfoReply(const char* sn, const char* fw) {
     uint8_t payload[60] = {0};
@@ -139,9 +151,9 @@ void test_happy_path_one_new_file() {
     enqueueOpeningExchange(mock);
     mock.enqueueResponse(buildFileListReply({"20260427213521"}));
 
-    // Per-file: F2 ack, then F3 returns one full chunk (8 bytes) + one shorter
-    // chunk (4 bytes) → loop ends on shorter, then F4 ack.
-    mock.enqueueResponse(buildEmptyReply(OP_READ_FILE_START));
+    // Per-file: F2 advertises size = 12, then F3 returns one 8-byte chunk +
+    // one 4-byte chunk; loop terminates when offset reaches advertised size.
+    mock.enqueueResponse(buildReadFileStartReply(12));
     {
         uint8_t chunk1[8] = {0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF, 0x11, 0x22};
         mock.enqueueResponse(buildFrame(OP_READ_FILE_DATA, chunk1, sizeof(chunk1)));
@@ -208,12 +220,11 @@ void test_dedup_skips_already_synced() {
     enqueueOpeningExchange(mock);
     mock.enqueueResponse(buildFileListReply({"20260427100000", "20260427213521"}));
     // Only the new filename should drive an F2/F3/F4 sequence.
-    mock.enqueueResponse(buildEmptyReply(OP_READ_FILE_START));
+    mock.enqueueResponse(buildReadFileStartReply(4));
     {
         uint8_t chunk[4] = {1, 2, 3, 4};
         mock.enqueueResponse(buildFrame(OP_READ_FILE_DATA, chunk, sizeof(chunk)));
     }
-    mock.enqueueResponse(buildEmptyReply(OP_READ_FILE_DATA));  // 0-byte chunk = end
     mock.enqueueResponse(buildEmptyReply(OP_READ_FILE_END));
 
     String pulled;
@@ -330,8 +341,9 @@ void test_file_transfer_disconnect_mid_pull_returns_file_transfer_failed() {
 
     enqueueOpeningExchange(mock);
     mock.enqueueResponse(buildFileListReply({"20260427213521"}));
-    mock.enqueueResponse(buildEmptyReply(OP_READ_FILE_START));
-    // First chunk arrives ...
+    // F2 advertises 8 bytes; F3 returns only the first 4, then queue is
+    // empty so the next F3 fetch times out before reaching advertised size.
+    mock.enqueueResponse(buildReadFileStartReply(8));
     {
         uint8_t chunk[4] = {1, 2, 3, 4};
         mock.enqueueResponse(buildFrame(OP_READ_FILE_DATA, chunk, sizeof(chunk)));
@@ -357,12 +369,11 @@ void test_on_file_complete_failure_leaves_filename_unsynced() {
 
     enqueueOpeningExchange(mock);
     mock.enqueueResponse(buildFileListReply({"20260427213521"}));
-    mock.enqueueResponse(buildEmptyReply(OP_READ_FILE_START));
+    mock.enqueueResponse(buildReadFileStartReply(4));
     {
         uint8_t chunk[4] = {1, 2, 3, 4};
         mock.enqueueResponse(buildFrame(OP_READ_FILE_DATA, chunk, sizeof(chunk)));
     }
-    mock.enqueueResponse(buildEmptyReply(OP_READ_FILE_DATA));  // EOF
     mock.enqueueResponse(buildEmptyReply(OP_READ_FILE_END));
 
     auto onComplete = [&](const String&, const uint8_t*, size_t) { return false; };
@@ -382,12 +393,11 @@ void test_dedup_pruned_to_ring_list() {
 
     enqueueOpeningExchange(mock);
     mock.enqueueResponse(buildFileListReply({"20260427213521"}));
-    mock.enqueueResponse(buildEmptyReply(OP_READ_FILE_START));
+    mock.enqueueResponse(buildReadFileStartReply(4));
     {
         uint8_t chunk[4] = {1, 2, 3, 4};
         mock.enqueueResponse(buildFrame(OP_READ_FILE_DATA, chunk, sizeof(chunk)));
     }
-    mock.enqueueResponse(buildEmptyReply(OP_READ_FILE_DATA));
     mock.enqueueResponse(buildEmptyReply(OP_READ_FILE_END));
 
     auto onComplete = [&](const String&, const uint8_t*, size_t) { return true; };

--- a/test/test_oxyii_sync/test_oxyii_sync.cpp
+++ b/test/test_oxyii_sync/test_oxyii_sync.cpp
@@ -18,7 +18,49 @@
 
 #include "OxyIIProtocol.h"
 #include "OxyIIAes.h"
+#include "O2RingFileSink.h"
 #include "O2RingOxyIISync.h"
+
+// In-memory sink for tests. Captures filename + concatenated chunks so the
+// original assertion patterns (filename, byte count, byte values) keep
+// working under the streaming contract. Knobs let tests simulate failure
+// at begin, at writeChunk, or at finalize.
+class MockFileSink : public O2RingFileSink {
+public:
+    bool failBegin = false;
+    int  failChunkAtIndex = -1;   // -1 = never fail; 0 = fail on first chunk; etc.
+
+    String              capturedFilename;
+    uint32_t            capturedTotalSize = 0;
+    std::vector<uint8_t> capturedBytes;
+    int                 chunkCount = 0;
+    bool                beginCalled = false;
+    bool                finalizeCalled = false;
+    bool                lastFinalizeOk = false;
+
+    bool begin(const String& filename, uint32_t totalSize) override {
+        beginCalled = true;
+        if (failBegin) return false;
+        capturedFilename = filename;
+        capturedTotalSize = totalSize;
+        capturedBytes.clear();
+        chunkCount = 0;
+        return true;
+    }
+    bool writeChunk(const uint8_t* data, size_t len) override {
+        if (failChunkAtIndex == chunkCount) {
+            chunkCount++;
+            return false;
+        }
+        capturedBytes.insert(capturedBytes.end(), data, data + len);
+        chunkCount++;
+        return true;
+    }
+    void finalize(bool ok) override {
+        finalizeCalled = true;
+        lastFinalizeOk = ok;
+    }
+};
 
 #include "../../src/OxyIIAes.cpp"
 #include "../../src/O2RingState.cpp"
@@ -131,8 +173,8 @@ void test_orchestrator_filters_scan_by_oxyii_service_uuid() {
     enqueueOpeningExchange(mock);
     mock.enqueueResponse(buildFileListReply({}));  // empty file list
 
-    auto onComplete = [&](const String&, const uint8_t*, size_t) { return true; };
-    O2RingOxyIISync sync(mock, state, defaultConfig(), onComplete);
+    MockFileSink sink;
+    O2RingOxyIISync sync(mock, state, defaultConfig(), sink);
     sync.run();
 
     // Service UUID must be the canonical OxyII one — robust to T8520_/S8-AW
@@ -164,25 +206,22 @@ void test_happy_path_one_new_file() {
     }
     mock.enqueueResponse(buildEmptyReply(OP_READ_FILE_END));
 
-    std::vector<uint8_t> capturedBytes;
-    String capturedFilename;
-    auto onComplete = [&](const String& fn, const uint8_t* data, size_t len) {
-        capturedFilename = fn;
-        capturedBytes.assign(data, data + len);
-        return true;
-    };
-
-    O2RingOxyIISync sync(mock, state, defaultConfig(), onComplete);
+    MockFileSink sink;
+    O2RingOxyIISync sync(mock, state, defaultConfig(), sink);
     O2RingSyncResult result = sync.run();
 
     TEST_ASSERT_EQUAL_INT((int)O2RingSyncResult::OK, (int)result);
     TEST_ASSERT_EQUAL_size_t(1, sync.lastSyncedCount());
     TEST_ASSERT_EQUAL_STRING("20260427213521", sync.lastSyncedFilename().c_str());
-    TEST_ASSERT_EQUAL_STRING("20260427213521", capturedFilename.c_str());
-    // 8 + 4 bytes pulled
-    TEST_ASSERT_EQUAL_size_t(12, capturedBytes.size());
-    TEST_ASSERT_EQUAL_UINT8(0xAA, capturedBytes[0]);
-    TEST_ASSERT_EQUAL_UINT8(0x66, capturedBytes[11]);
+    TEST_ASSERT_EQUAL_STRING("20260427213521", sink.capturedFilename.c_str());
+    TEST_ASSERT_EQUAL_UINT32(12, sink.capturedTotalSize);
+    // 8 + 4 bytes pulled — chunks streamed individually
+    TEST_ASSERT_EQUAL_size_t(12, sink.capturedBytes.size());
+    TEST_ASSERT_EQUAL_INT(2, sink.chunkCount);
+    TEST_ASSERT_EQUAL_UINT8(0xAA, sink.capturedBytes[0]);
+    TEST_ASSERT_EQUAL_UINT8(0x66, sink.capturedBytes[11]);
+    TEST_ASSERT_TRUE(sink.finalizeCalled);
+    TEST_ASSERT_TRUE(sink.lastFinalizeOk);
     // dedup state recorded the filename
     TEST_ASSERT_TRUE(state.hasSeen("20260427213521"));
     // requestMtu called once with 247
@@ -201,8 +240,8 @@ void test_happy_path_no_new_files_returns_ok() {
     mock.enqueueResponse(buildFileListReply({"20260427213521"}));
     // No F2/F3/F4 expected — file is already synced.
 
-    auto onComplete = [&](const String&, const uint8_t*, size_t) { return true; };
-    O2RingOxyIISync sync(mock, state, defaultConfig(), onComplete);
+    MockFileSink sink;
+    O2RingOxyIISync sync(mock, state, defaultConfig(), sink);
 
     O2RingSyncResult result = sync.run();
 
@@ -227,18 +266,14 @@ void test_dedup_skips_already_synced() {
     }
     mock.enqueueResponse(buildEmptyReply(OP_READ_FILE_END));
 
-    String pulled;
-    auto onComplete = [&](const String& fn, const uint8_t*, size_t) {
-        pulled = fn;
-        return true;
-    };
-    O2RingOxyIISync sync(mock, state, defaultConfig(), onComplete);
+    MockFileSink sink;
+    O2RingOxyIISync sync(mock, state, defaultConfig(), sink);
 
     O2RingSyncResult result = sync.run();
 
     TEST_ASSERT_EQUAL_INT((int)O2RingSyncResult::OK, (int)result);
     TEST_ASSERT_EQUAL_size_t(1, sync.lastSyncedCount());
-    TEST_ASSERT_EQUAL_STRING("20260427213521", pulled.c_str());
+    TEST_ASSERT_EQUAL_STRING("20260427213521", sink.capturedFilename.c_str());
 }
 
 // -------------------- error branches --------------------
@@ -250,8 +285,8 @@ void test_connect_fails_returns_connect_failed_when_device_found() {
     O2RingState state;
     state.load();
 
-    auto onComplete = [&](const String&, const uint8_t*, size_t) { return true; };
-    O2RingOxyIISync sync(mock, state, defaultConfig(), onComplete);
+    MockFileSink sink;
+    O2RingOxyIISync sync(mock, state, defaultConfig(), sink);
 
     TEST_ASSERT_EQUAL_INT((int)O2RingSyncResult::CONNECT_FAILED, (int)sync.run());
 }
@@ -263,8 +298,8 @@ void test_connect_fails_returns_no_device_found_when_scan_empty() {
     O2RingState state;
     state.load();
 
-    auto onComplete = [&](const String&, const uint8_t*, size_t) { return true; };
-    O2RingOxyIISync sync(mock, state, defaultConfig(), onComplete);
+    MockFileSink sink;
+    O2RingOxyIISync sync(mock, state, defaultConfig(), sink);
 
     TEST_ASSERT_EQUAL_INT((int)O2RingSyncResult::NO_DEVICE_FOUND, (int)sync.run());
 }
@@ -275,8 +310,8 @@ void test_mtu_negotiation_below_target_returns_mtu_failed() {
     O2RingState state;
     state.load();
 
-    auto onComplete = [&](const String&, const uint8_t*, size_t) { return true; };
-    O2RingOxyIISync sync(mock, state, defaultConfig(), onComplete);
+    MockFileSink sink;
+    O2RingOxyIISync sync(mock, state, defaultConfig(), sink);
 
     TEST_ASSERT_EQUAL_INT((int)O2RingSyncResult::MTU_FAILED, (int)sync.run());
 }
@@ -292,8 +327,8 @@ void test_auth_no_reply_proceeds_to_keepalive() {
     O2RingState state;
     state.load();
 
-    auto onComplete = [&](const String&, const uint8_t*, size_t) { return true; };
-    O2RingOxyIISync sync(mock, state, defaultConfig(), onComplete);
+    MockFileSink sink;
+    O2RingOxyIISync sync(mock, state, defaultConfig(), sink);
 
     TEST_ASSERT_EQUAL_INT((int)O2RingSyncResult::HANDSHAKE_FAILED, (int)sync.run());
     // Confirm AUTH was actually written despite no reply.
@@ -314,8 +349,8 @@ void test_get_info_reply_with_no_serial_returns_get_info_failed() {
     // GET_INFO reply with sn_len = 0
     mock.enqueueResponse(buildGetInfoReply("", "2D010002"));
 
-    auto onComplete = [&](const String&, const uint8_t*, size_t) { return true; };
-    O2RingOxyIISync sync(mock, state, defaultConfig(), onComplete);
+    MockFileSink sink;
+    O2RingOxyIISync sync(mock, state, defaultConfig(), sink);
 
     TEST_ASSERT_EQUAL_INT((int)O2RingSyncResult::GET_INFO_FAILED, (int)sync.run());
 }
@@ -328,8 +363,8 @@ void test_file_list_missing_returns_file_list_failed() {
     enqueueOpeningExchange(mock);
     // No GET_FILE_LIST reply enqueued.
 
-    auto onComplete = [&](const String&, const uint8_t*, size_t) { return true; };
-    O2RingOxyIISync sync(mock, state, defaultConfig(), onComplete);
+    MockFileSink sink;
+    O2RingOxyIISync sync(mock, state, defaultConfig(), sink);
 
     TEST_ASSERT_EQUAL_INT((int)O2RingSyncResult::FILE_LIST_FAILED, (int)sync.run());
 }
@@ -350,15 +385,16 @@ void test_file_transfer_disconnect_mid_pull_returns_file_transfer_failed() {
     }
     // ... but the next F3 read times out (no more responses queued).
 
-    bool callbackInvoked = false;
-    auto onComplete = [&](const String&, const uint8_t*, size_t) {
-        callbackInvoked = true;
-        return true;
-    };
-    O2RingOxyIISync sync(mock, state, defaultConfig(), onComplete);
+    MockFileSink sink;
+    O2RingOxyIISync sync(mock, state, defaultConfig(), sink);
 
     TEST_ASSERT_EQUAL_INT((int)O2RingSyncResult::FILE_TRANSFER_FAILED, (int)sync.run());
-    TEST_ASSERT_FALSE(callbackInvoked);
+    // Sink was opened (begin called) and a chunk was forwarded, but the
+    // disconnect mid-pull aborted before the F4 close — finalize must
+    // still fire with ok=false so the partial write is cleaned up.
+    TEST_ASSERT_TRUE(sink.beginCalled);
+    TEST_ASSERT_TRUE(sink.finalizeCalled);
+    TEST_ASSERT_FALSE(sink.lastFinalizeOk);
     TEST_ASSERT_FALSE(state.hasSeen("20260427213521"));
 }
 
@@ -376,10 +412,15 @@ void test_on_file_complete_failure_leaves_filename_unsynced() {
     }
     mock.enqueueResponse(buildEmptyReply(OP_READ_FILE_END));
 
-    auto onComplete = [&](const String&, const uint8_t*, size_t) { return false; };
-    O2RingOxyIISync sync(mock, state, defaultConfig(), onComplete);
+    // Streaming-equivalent of "callback returned false": sink fails on
+    // the first chunk, simulating a downstream-write error.
+    MockFileSink sink;
+    sink.failChunkAtIndex = 0;
+    O2RingOxyIISync sync(mock, state, defaultConfig(), sink);
 
     TEST_ASSERT_EQUAL_INT((int)O2RingSyncResult::FILE_TRANSFER_FAILED, (int)sync.run());
+    TEST_ASSERT_TRUE(sink.finalizeCalled);
+    TEST_ASSERT_FALSE(sink.lastFinalizeOk);
     TEST_ASSERT_FALSE(state.hasSeen("20260427213521"));
 }
 
@@ -400,8 +441,8 @@ void test_dedup_pruned_to_ring_list() {
     }
     mock.enqueueResponse(buildEmptyReply(OP_READ_FILE_END));
 
-    auto onComplete = [&](const String&, const uint8_t*, size_t) { return true; };
-    O2RingOxyIISync sync(mock, state, defaultConfig(), onComplete);
+    MockFileSink sink;
+    O2RingOxyIISync sync(mock, state, defaultConfig(), sink);
     sync.run();
 
     // After sync: stale entry pruned, current one retained


### PR DESCRIPTION
## Summary

Hardware-validated against a real Wellue O2Ring-S (T8520, sn 25B2303210, fw 2D010002): button click → BLE scan → connect → MTU → command flow → 80 KB file streamed straight to SMB. 6 commits, none of which work on their own — each was uncovered by hardware testing the previous one.

- **Web UI button**: dashboard's O2Ring Sync card now has a "Sync Now" button. Backend `GET /trigger-o2ring-sync` flips a flag; main loop transitions FSM straight to `O2RING_SYNC`, bypassing remaining cooldown. Rejects with `status=busy` if upload is running, `status=disabled` if `O2RING_ENABLED=false`.
- **Scan filter** widened to match `pull_v2.py`'s four OxyII signatures (address prefix `F3:7F:ED`, manuf id `0xF34E`, name prefix `S8-AW`, service UUID). The post-#12 single-UUID filter missed the ring on essentially every scan because the OxyII service UUID is described in the protocol walkthrough as "rare" in advertisements.
- **AUTH (0xFF) fire-and-forget**: ring never sends an AUTH reply (confirmed across pair/sync/our snoops; pull_v2.py mirrors). Add `expectReply` / `postSendDelayMs` to `sendCommand`, call AUTH with `expectReply=false` and a 1s pause.
- **READ_FILE_START is plaintext**, not AES — protocol walkthrough is explicit: "Only cmd=0xFF (auth) is AES-encrypted." Switch from `sendEncryptedCommand` → `sendCommand`. Wire up the u32 LE file size from F2's reply to bound the F3 loop.
- **Streaming sink**: replace the OnFileComplete callback with `O2RingFileSink` (begin/writeChunk/finalize). Each F3 chunk forwards straight from BLE notify → `smb2_write` — peak RAM during a file pull is one chunk (~240 B) regardless of file size. Required because real-world ~80 KB files don't fit in the ~30 KB max contiguous heap available at sync time after WiFi + NimBLE + libsmb2 + web server come up. Buffer-then-upload would crash with `bad_alloc` on those files.

## Test plan

- [x] 192/192 native unit tests pass (`pio test -e native`)
- [x] `pio run -e pico32` builds clean (+~3 KB total flash, RAM unchanged)
- [x] Hardware: button click → ring found via `addr-prefix` at -50 dBm
- [x] Hardware: 80 KB file streamed end-to-end to `/oximetry/raw/<device>/<filename>.dat`
- [x] Hardware: 634 B file pulled in <1s after the big one
- [x] Dedup: previously-synced files skipped on re-trigger
- [ ] Verify uploaded files match SHA256 of the bumble-pulled fixtures
- [ ] Long-soak: leave the FSM running overnight to confirm no regressions in the existing CPAP upload path

🤖 Generated with [Claude Code](https://claude.com/claude-code)