### PR TITLE
fix(fsm): detach web server during runUploadBlocking

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -587,6 +587,14 @@ void uploadTaskFunction(void* pvParameters) {
 }
 
 static void runUploadBlocking(DataFilter filter) {
+#ifdef ENABLE_WEBSERVER
+    // Detach the uploader's handleClient() pump while we're running an
+    // SMB transfer on the loop core. Servicing a request mid-blocking-
+    // upload allocates against an already-fragmented heap inside
+    // WebServer/WiFiClient and can wedge the listener socket until
+    // reboot. We accept a dark web UI for the upload window in exchange.
+    uploader->setWebServer(nullptr);
+#endif
     int maxMinutes = config.getExclusiveAccessMinutes();
     UploadResult result = uploader->uploadWithExclusiveAccess(&sdManager, maxMinutes, filter);
     switch (result) {
@@ -607,6 +615,9 @@ static void runUploadBlocking(DataFilter filter) {
             transitionTo(UploadState::RELEASING);
             break;
     }
+#ifdef ENABLE_WEBSERVER
+    uploader->setWebServer(webServer);
+#endif
 }
 
 void handleUploading() {


### PR DESCRIPTION
## Summary

The blocking-upload fallback in `runUploadBlocking` left the WebServer attached to the uploader's `handleClient()` pump. A request hitting the listener mid-SMB transfer would allocate response buffers against an already-fragmented heap inside `WebServer`/`WiFiClient`, and could leave the listener socket in a state that required a physical reboot to recover (network stack alive, ICMP fine, HTTP wedged for 4+ minutes).

The async path at `xTaskCreatePinnedToCore` already detaches the pump for the duration of the upload task. This PR makes the blocking path symmetric: detach at `runUploadBlocking` entry, restore at exit. Web UI goes dark during the blocking-upload window; in exchange the listener stays safe.

The blocking path is hit when `maxAllocBeforeTask < UPLOAD_ASYNC_MIN_MAX_ALLOC_BYTES` (50KB), which trips every cycle on heap-tight configurations (e.g. with `ENABLE_O2RING_SYNC=1` where NimBLE eats ~34KB of init heap). Investigation showed the contiguous-heap drop is caused by `sdManager.takeControl()` mounting SD_MMC (8KB DMA + ~28KB free heap) plus boot-time mbedTLS handshake fragmentation, not by the FSM reorder.

## Test plan

- [x] `pio run -e pico32` — clean build, identical flash/RAM footprint
- [x] `pio test -e native` — 230/230 native tests pass on this branch
- [x] On-device capture of a full FSM cycle on the dev card (boot → LISTENING → ACQUIRING → O2RING_SYNC → UPLOADING → RELEASING → COOLDOWN) confirmed the detach/restore path is reachable

🤖 Generated with [Claude Code](https://claude.com/claude-code)