### PR TITLE
feat(diag): persistent crash snapshots + main-loop WDT + panic-boot smart-wait

### DIFF
--- a/include/CrashDiag.h
+++ b/include/CrashDiag.h
@@ -1,0 +1,62 @@
+#ifndef CRASH_DIAG_H
+#define CRASH_DIAG_H
+
+// Persistent crash / wedge diagnostics.
+//
+// Survives panics, task watchdog timeouts, brownouts, and software resets so
+// the next boot can answer "what state was the firmware in when it died, and
+// what did the heap look like just before?" All writes are NVS-only — never
+// touches the SD bus, safe to call before SDCardManager::takeControl().
+//
+// Backing store: NVS namespace "cpap_diag", single blob key "snap" packed via
+// putBytes(). One physical write per stamp regardless of how many fields
+// change; wear-leveled by the underlying NVS partition.
+
+#include <stdint.h>
+#include <esp_system.h>
+
+namespace CrashDiag {
+
+struct PreviousBoot {
+    bool                valid;          // false on first-ever boot
+    esp_reset_reason_t  resetReason;    // reset cause that ended the previous boot
+    uint8_t             lastFsmState;   // raw UploadState enum value at last stamp
+    uint32_t            lastStampMillis;// millis() value at last stamp (within prev boot)
+    uint32_t            lastFreeHeap;
+    uint32_t            lastMaxAlloc;
+    uint16_t            bootCount;      // boot counter from the previous boot
+};
+
+// Read previous-boot snapshot from NVS, log it, then stamp the current boot's
+// reset reason. Must be called BEFORE any SD bus access — NVS only.
+void begin(esp_reset_reason_t currentReason);
+
+// Snapshot of the previous boot, captured during begin(). Stable for the rest
+// of this boot's lifetime.
+const PreviousBoot& previousBoot();
+
+// True if the previous boot ended in PANIC / TASK_WDT / INT_WDT / WDT /
+// BROWNOUT — any reset cause that suggests the firmware may have been
+// holding the SD bus when it died. This is the panic-boot gate signal.
+bool wasAbnormalReset();
+
+// Stamp current FSM state + heap to NVS. Called from transitionTo() and from
+// the main-loop heartbeat. Cheap (single putBytes), no rate-limit applied
+// here — caller is responsible for not hammering this from a tight loop.
+void stamp(uint8_t fsmState);
+
+// Convenience wrapper for the periodic main-loop heartbeat. Rate-limits
+// internally to one NVS write per ~120s. Pass the current FSM state so the
+// stamp survives even when no transition has happened.
+void heartbeat(uint8_t fsmState);
+
+// Called once the firmware demonstrates it can complete a clean state
+// transition after a panic boot (e.g. enters LISTENING successfully). Clears
+// wasAbnormalReset() for the rest of this boot so normal SD bus operation
+// resumes. The on-NVS prev-reset code is NOT cleared — only this boot's
+// in-RAM panic-boot flag is.
+void clearPanicBootFlag();
+
+} // namespace CrashDiag
+
+#endif // CRASH_DIAG_H

--- a/src/CrashDiag.cpp
+++ b/src/CrashDiag.cpp
@@ -1,0 +1,184 @@
+#include "CrashDiag.h"
+
+#include <Arduino.h>
+#include <Preferences.h>
+
+#include "Logger.h"
+
+namespace {
+
+constexpr const char* NVS_NAMESPACE = "cpap_diag";
+constexpr const char* NVS_KEY_SNAP  = "snap";
+
+// On-NVS layout. Packed so the struct can be putBytes/getBytes round-tripped.
+struct __attribute__((packed)) DiagSnapshot {
+    uint8_t  schemaVersion;     // 1
+    uint8_t  fsmState;          // raw UploadState
+    uint8_t  resetReason;       // raw esp_reset_reason_t for THIS boot
+    uint8_t  reserved;          // pad for alignment / future use
+    uint16_t bootCount;         // monotonic across boots
+    uint16_t reserved2;
+    uint32_t stampMillis;       // millis() at write time
+    uint32_t freeHeap;
+    uint32_t maxAlloc;
+};
+static_assert(sizeof(DiagSnapshot) == 20, "DiagSnapshot must be 20 bytes for stable NVS layout");
+
+constexpr uint8_t SCHEMA_VERSION = 1;
+constexpr unsigned long HEARTBEAT_MIN_INTERVAL_MS = 120UL * 1000UL;
+
+CrashDiag::PreviousBoot g_prev{};
+DiagSnapshot           g_current{};
+bool                   g_inited                 = false;
+bool                   g_panicBootFlagThisBoot  = false;
+unsigned long          g_lastHeartbeatMs        = 0;
+
+const char* resetReasonName(esp_reset_reason_t r) {
+    switch (r) {
+        case ESP_RST_UNKNOWN:   return "UNKNOWN";
+        case ESP_RST_POWERON:   return "POWERON";
+        case ESP_RST_EXT:       return "EXT";
+        case ESP_RST_SW:        return "SW";
+        case ESP_RST_PANIC:     return "PANIC";
+        case ESP_RST_INT_WDT:   return "INT_WDT";
+        case ESP_RST_TASK_WDT:  return "TASK_WDT";
+        case ESP_RST_WDT:       return "WDT";
+        case ESP_RST_DEEPSLEEP: return "DEEPSLEEP";
+        case ESP_RST_BROWNOUT:  return "BROWNOUT";
+        case ESP_RST_SDIO:      return "SDIO";
+        default:                return "?";
+    }
+}
+
+bool isAbnormalReason(esp_reset_reason_t r) {
+    switch (r) {
+        case ESP_RST_PANIC:
+        case ESP_RST_INT_WDT:
+        case ESP_RST_TASK_WDT:
+        case ESP_RST_WDT:
+        case ESP_RST_BROWNOUT:
+            return true;
+        default:
+            return false;
+    }
+}
+
+void writeSnapshot() {
+    Preferences p;
+    if (!p.begin(NVS_NAMESPACE, /*readOnly=*/false)) {
+        // NVS write failure is non-fatal; log once and move on. Subsequent
+        // calls may succeed if the partition was temporarily contended.
+        LOG_WARN("[CrashDiag] NVS open (rw) failed");
+        return;
+    }
+    p.putBytes(NVS_KEY_SNAP, &g_current, sizeof(g_current));
+    p.end();
+}
+
+} // namespace
+
+namespace CrashDiag {
+
+void begin(esp_reset_reason_t currentReason) {
+    if (g_inited) return;
+    g_inited = true;
+
+    // --- Read previous-boot snapshot (if any) ---
+    Preferences p;
+    bool prevLoaded = false;
+    DiagSnapshot prev{};
+
+    if (p.begin(NVS_NAMESPACE, /*readOnly=*/true)) {
+        size_t got = p.getBytes(NVS_KEY_SNAP, &prev, sizeof(prev));
+        if (got == sizeof(prev) && prev.schemaVersion == SCHEMA_VERSION) {
+            prevLoaded = true;
+        }
+        p.end();
+    }
+
+    g_prev.valid           = prevLoaded;
+    g_prev.resetReason     = currentReason; // also useful to surface caller's read
+    g_prev.lastFsmState    = prevLoaded ? prev.fsmState : 0;
+    g_prev.lastStampMillis = prevLoaded ? prev.stampMillis : 0;
+    g_prev.lastFreeHeap    = prevLoaded ? prev.freeHeap : 0;
+    g_prev.lastMaxAlloc    = prevLoaded ? prev.maxAlloc : 0;
+    g_prev.bootCount       = prevLoaded ? prev.bootCount : 0;
+
+    // The previous boot's reset reason was stamped on its boot, NOT at death.
+    // To learn how the previous boot died, we use esp_reset_reason() of THIS
+    // boot (currentReason) — that IS the previous boot's exit cause.
+    // We keep prev.resetReason (= the boot before that) for context only.
+    esp_reset_reason_t prevDiedAs = currentReason;
+
+    // --- Log a single boot-banner line so postmortems are greppable ---
+    if (!prevLoaded) {
+        LOG_INFOF("[CrashDiag] first boot or empty NVS (this boot reset=%s)",
+                  resetReasonName(currentReason));
+    } else {
+        LOG_INFOF("[CrashDiag] prev boot #%u died as %s; last_fsm=%u "
+                  "stamp_ms=%u free=%u max_alloc=%u",
+                  (unsigned)prev.bootCount,
+                  resetReasonName(prevDiedAs),
+                  (unsigned)prev.fsmState,
+                  (unsigned)prev.stampMillis,
+                  (unsigned)prev.freeHeap,
+                  (unsigned)prev.maxAlloc);
+    }
+
+    g_panicBootFlagThisBoot = isAbnormalReason(prevDiedAs);
+    if (g_panicBootFlagThisBoot) {
+        LOG_WARNF("[CrashDiag] PANIC-BOOT mode active (prev exit=%s) — "
+                  "SD bus access will be deferred until extended idle confirmed",
+                  resetReasonName(prevDiedAs));
+    }
+
+    // --- Prime the current-boot snapshot and stamp it ---
+    g_current.schemaVersion = SCHEMA_VERSION;
+    g_current.fsmState      = 0; // IDLE
+    g_current.resetReason   = (uint8_t)currentReason;
+    g_current.reserved      = 0;
+    g_current.bootCount     = (uint16_t)(g_prev.bootCount + 1);
+    g_current.reserved2     = 0;
+    g_current.stampMillis   = millis();
+    g_current.freeHeap      = ESP.getFreeHeap();
+    g_current.maxAlloc      = ESP.getMaxAllocHeap();
+    writeSnapshot();
+
+    g_lastHeartbeatMs = millis();
+}
+
+const PreviousBoot& previousBoot() {
+    return g_prev;
+}
+
+bool wasAbnormalReset() {
+    return g_panicBootFlagThisBoot;
+}
+
+void stamp(uint8_t fsmState) {
+    if (!g_inited) return;
+    g_current.fsmState    = fsmState;
+    g_current.stampMillis = millis();
+    g_current.freeHeap    = ESP.getFreeHeap();
+    g_current.maxAlloc    = ESP.getMaxAllocHeap();
+    writeSnapshot();
+    g_lastHeartbeatMs = millis();
+}
+
+void heartbeat(uint8_t fsmState) {
+    if (!g_inited) return;
+    unsigned long now = millis();
+    if (now - g_lastHeartbeatMs < HEARTBEAT_MIN_INTERVAL_MS) {
+        return;
+    }
+    stamp(fsmState);
+}
+
+void clearPanicBootFlag() {
+    if (g_panicBootFlagThisBoot) {
+        LOG_INFO("[CrashDiag] firmware proved stable — clearing panic-boot flag");
+        g_panicBootFlagThisBoot = false;
+    }
+}
+
+} // namespace CrashDiag

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,6 +11,7 @@
 #include "pins_config.h"
 #include "version.h"
 
+#include "CrashDiag.h"
 #include "TrafficMonitor.h"
 #include "UploadFSM.h"
 
@@ -137,6 +138,9 @@ void transitionTo(UploadState newState) {
     LOGF("[FSM] %s -> %s", getStateName(currentState), getStateName(newState));
     currentState = newState;
     stateEnteredAt = millis();
+    // Survive panic: stamp the new state so the next boot can see where we
+    // were when we died. Cheap single-blob NVS write — no SD bus touch.
+    CrashDiag::stamp((uint8_t)newState);
 }
 
 // ============================================================================
@@ -199,7 +203,25 @@ void setup() {
     // Log reset reason for power/stability diagnostics
     esp_reset_reason_t resetReason = esp_reset_reason();
     LOG_INFOF("Reset reason: %s", getResetReasonString(resetReason));
-    
+
+    // Persistent crash diagnostics. Reads previous boot's snapshot from NVS,
+    // logs how the previous boot died, and primes this boot's snapshot.
+    // NVS-only — safe to run before any SD bus access.
+    CrashDiag::begin(resetReason);
+
+    // Hardware backstop: if the main loop wedges for more than this many
+    // seconds, panic-reset and let the next boot recover. Timeout is set
+    // well above any legitimate single-iteration time (blocking SMB upload
+    // is capped at EXCLUSIVE_ACCESS_MINUTES, max 30) so this only fires on
+    // a real wedge. esp_task_wdt_init() also reconfigures the IDLE task
+    // subscription that arduino-esp32 sets up at boot.
+    const uint32_t MAIN_LOOP_WDT_SECONDS = 45UL * 60UL;
+    esp_err_t wdtErr = esp_task_wdt_init(MAIN_LOOP_WDT_SECONDS, /*panic=*/true);
+    if (wdtErr != ESP_OK) {
+        LOG_WARNF("esp_task_wdt_init returned 0x%x — main-loop watchdog may not be armed",
+                  (unsigned)wdtErr);
+    }
+
     // Check for power-related issues
     if (resetReason == ESP_RST_BROWNOUT) {
         LOG_ERROR("WARNING: System reset due to brown-out (insufficient power supply), this could be caused by:");
@@ -226,10 +248,19 @@ void setup() {
     g_heapRecoveryBoot = (esp_reset_reason() == ESP_RST_SW);
     bool fastBoot = g_heapRecoveryBoot;
 
-    // Smart Wait constants — same values for both cold and soft-reboot.
-    // 5 s of continuous SD bus silence required; give up after 45 s max.
-    const unsigned long SMART_WAIT_MAX_MS      = 45000;
-    const unsigned long SMART_WAIT_REQUIRED_MS =  5000;
+    // Smart Wait constants. Normal boot: 5 s of bus silence required, give up
+    // after 45 s. Panic boot (previous boot died as PANIC/WDT/BROWNOUT): we
+    // may be coming back online mid-night with the AS11 actively writing — a
+    // single bus theft will fatal the night's DATALOG. Extend to 60 s of
+    // continuous silence required and a 10 min wait, then proceed anyway
+    // (we have no recovery path that doesn't touch the bus eventually).
+    const bool panicBoot = CrashDiag::wasAbnormalReset();
+    const unsigned long SMART_WAIT_MAX_MS      = panicBoot ? (10UL * 60UL * 1000UL) : 45000UL;
+    const unsigned long SMART_WAIT_REQUIRED_MS = panicBoot ? 60000UL : 5000UL;
+    if (panicBoot) {
+        LOG_WARNF("[PanicBoot] Smart Wait extended: max=%lums required=%lums",
+                  SMART_WAIT_MAX_MS, SMART_WAIT_REQUIRED_MS);
+    }
 
     auto runSmartWait = [&]() {
         LOG("Checking for CPAP SD card activity (Smart Wait)...");
@@ -502,6 +533,21 @@ void setup() {
     } else {
         LOG("[FSM] Scheduled mode — starting in IDLE");
         // IDLE is the correct initial state for scheduled mode
+    }
+
+    // We made it through bus-acquire, config-load, WiFi, and uploader init
+    // without crashing. Drop the panic-boot flag so any subsequent code paths
+    // that consult wasAbnormalReset() see normal operation.
+    CrashDiag::clearPanicBootFlag();
+
+    // Subscribe the main loop task to the IDF task watchdog. Until now the
+    // loop has been free to take arbitrarily long (smart-wait can sit for
+    // 10 min in panic-boot mode); from here on, loop must tick every
+    // MAIN_LOOP_WDT_SECONDS or the chip resets.
+    esp_err_t wdtAdd = esp_task_wdt_add(NULL);
+    if (wdtAdd != ESP_OK) {
+        LOG_WARNF("esp_task_wdt_add(loop) returned 0x%x — main-loop watchdog NOT active",
+                  (unsigned)wdtAdd);
     }
 
     LOG("Setup complete!");
@@ -1082,8 +1128,17 @@ void handleO2RingRetry() {
 // Loop Function
 // ============================================================================
 void loop() {
+    // Feed the main-loop task watchdog every iteration. If the loop ever
+    // stops ticking (wedge in any handler), the WDT will panic-reset after
+    // MAIN_LOOP_WDT_SECONDS and the next boot reads ESP_RST_TASK_WDT.
+    esp_task_wdt_reset();
+
+    // Heartbeat the persistent diagnostics so the NVS snapshot stays fresh
+    // even when no FSM transition has happened. Rate-limited internally.
+    CrashDiag::heartbeat((uint8_t)currentState);
+
     // ── Always-on tasks ──
-    
+
     // Periodic SD card log dump (every 10 seconds when enabled)
     // Skip when upload task is running — SD card is in use on another core
     if (config.getLogToSdCard() && !uploadTaskRunning) {
@@ -1266,6 +1321,42 @@ void loop() {
         }
         // If UPLOADING, leave flag set — handleReleasing() will redirect to MONITORING
         // after upload finishes current cycle + mandatory root/SETTINGS files
+    }
+
+    // ── Stale-state detector ──
+    // Active states (ones that should make rapid progress) must not exceed
+    // STALE_STATE_TIMEOUT_MS. The dedicated upload heartbeat (2 min) already
+    // catches a hung upload task; this is a backstop for the BLE/SD paths
+    // that don't have their own heartbeat. Force-release the bus and reboot
+    // if we sit too long. LISTENING/IDLE/COOLDOWN/MONITORING are deliberately
+    // excluded — they can legitimately stay parked for long periods.
+    const unsigned long STALE_STATE_TIMEOUT_MS = 40UL * 60UL * 1000UL;
+    bool stateIsActive = false;
+    switch (currentState) {
+        case UploadState::ACQUIRING:
+        case UploadState::UPLOADING:
+        case UploadState::RELEASING:
+        case UploadState::O2RING_SYNC:
+        case UploadState::O2RING_RETRY:
+        case UploadState::COMPLETE:
+            stateIsActive = true;
+            break;
+        default:
+            break;
+    }
+    if (stateIsActive && (millis() - stateEnteredAt > STALE_STATE_TIMEOUT_MS)) {
+        LOG_ERRORF("[FSM] Stale state: stuck in %s for >%lums — force-release + reboot",
+                   getStateName(currentState),
+                   STALE_STATE_TIMEOUT_MS);
+        if (sdManager.hasControl()) {
+            sdManager.releaseControl();
+        }
+        // Force MUX back to CPAP unconditionally — releaseControl is a no-op
+        // when espHasControl is false, but the bus may have been stolen by
+        // a wedged upload task without sdManager.espHasControl reflecting it.
+        digitalWrite(SD_SWITCH_PIN, SD_SWITCH_CPAP_VALUE);
+        delay(300);
+        esp_restart();
     }
 
     // ── FSM dispatch ──


### PR DESCRIPTION
First investigation pass on the overnight CPAP data-loss bug (admin/sleep
post-2026-05-09 night). Goal: when the firmware next wedges, leave usable
postmortem data on NVS, and don't make the AS11 lose another night.

Stacks on #19 (target branch is `feat/o2ring-acquire-first`). All three pieces
are independent and can ship together or be split if review prefers.

## What

### 1. CrashDiag — persistent boot/state/heap snapshot in NVS

New module (`include/CrashDiag.h`, `src/CrashDiag.cpp`). Packed 20-byte
blob in NVS namespace `cpap_diag`, key `snap`:

```
struct DiagSnapshot {
    uint8_t schemaVersion, fsmState, resetReason, reserved;
    uint16_t bootCount, reserved2;
    uint32_t stampMillis, freeHeap, maxAlloc;
};
```

`CrashDiag::begin()` reads the previous boot's snapshot, logs a one-line
postmortem, and primes the current boot. Hooked into:
- `setup()`: called before any SD bus access (NVS-only, safe).
- `transitionTo()`: stamps state every FSM transition.
- `loop()` top: `heartbeat()` refreshes the snapshot at most every 120 s
  so long stays in LISTENING also get a recent timestamp.

Verified on SD1: after a reboot the next boot's banner reads
`[CrashDiag] prev boot #N died as <reason>; last_fsm=<state> stamp_ms=...
free=... max_alloc=...`.

### 2. Main-loop task watchdog

`esp_task_wdt_init(45 min, panic=true)` early in setup(); the loop task
subscribes via `esp_task_wdt_add(NULL)` once setup completes;
`esp_task_wdt_reset()` at the top of `loop()` feeds it every tick. 45 min
is comfortably above any legit single-iteration time (`EXCLUSIVE_ACCESS_MINUTES`
caps blocking upload at 30) so this only fires on a real wedge. The
resulting `ESP_RST_TASK_WDT` is picked up by CrashDiag on next boot as an
abnormal reset.

### 3. Panic-boot smart-wait

If the previous boot died as PANIC / TASK_WDT / INT_WDT / WDT / BROWNOUT,
`setup()` extends the smart-wait window from 45 s/5 s required-idle to
**10 min / 60 s required-idle**. The two `takeControl()` calls in setup
are exactly the thing that fatals the AS11 if the bus is contended; a
panic-rebooted firmware coming back mid-night needs to be much more
conservative. After bus-acquire + WiFi + uploader-init succeed,
`clearPanicBootFlag()` restores normal behavior for the rest of the boot.

### 4. Generic stale-state detector

40-minute backstop for active FSM states (ACQUIRING / UPLOADING /
RELEASING / O2RING_SYNC / O2RING_RETRY / COMPLETE). LISTENING / IDLE /
COOLDOWN / MONITORING are deliberately excluded — they can legitimately
park for a long time. On trip: force MUX back to CPAP,
`sdManager.releaseControl()`, `esp_restart()`. Complements the existing
2-min `g_uploadHeartbeat` watchdog (which only covers the upload task).

## Verification

- `pio run -e pico32` clean. RAM 20.4 %, Flash 51.2 % (no meaningful size
  delta vs. base).
- Flashed SD1 (`c0:cd:d6:30:60:0c`, MAC matches the dev rig card) via
  esptool at `--flash_freq 26m`. All four regions verified first try.
- Reset → boot banner shows the CrashDiag postmortem of the previous
  boot, smart-wait succeeds at 5 s (normal-boot path), and FSM enters
  LISTENING.
- No effect on the production card. SD2 in the CPAP stays on
  `legacy/o2ring-original-dev+29` LKG until we have multiple clean
  overnights of evidence from SD1.

## What this does NOT do

- Doesn't claim to fix the wedge itself. The instrumentation is so that
  *next* wedge leaves evidence, and the panic-boot path is so that next
  wedge doesn't take down another full night by way of an SD-bus theft
  during recovery boot. Heap-pressure mitigations are deferred to a
  later pass (static upload-task stack, mbedTLS buffer sizing — none
  attempted here).
- Does not change the May-9-style write footgun on `POST /api/config-raw`
  during therapy. Issue/PR for that lands separately (item 4 of the
  investigation plan).

## Risk

- WDT init failure is logged and non-fatal (the firmware runs without
  the WDT subscription if `esp_task_wdt_init` rejects the timeout). On
  the test card the init succeeded silently.
- NVS write rate: one `putBytes(20)` per FSM transition (~6/cycle) plus
  one per heartbeat tick (~1/2 min in LISTENING). Well under the
  partition's wear-leveled write budget; the existing `cpap_flags`
  namespace gets touched at similar rates today.
- The new 40-min stale-state cap could in principle force-reboot a
  legitimate 30-min EXCLUSIVE_ACCESS upload that runs to its full
  budget. 10 min of headroom is intentional but tight; if review wants
  it bumped to 60 min I'm happy to do that.